### PR TITLE
Allow arrays of chunks in addition to start and end

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -3,9 +3,19 @@ import PropTypes from 'prop-types';
 
 import { publicationType } from './types';
 
+const getStart = (chunks) => {
+  const { start, numbers } = chunks;
+
+  if (start) {
+    return start;
+  }
+
+  return numbers[0];
+};
+
 const renderSection = (section) => {
   const { locus, path, chunks } = section;
-  const { start } = chunks;
+  const start = getStart(chunks);
 
   return (
     <React.Fragment key={path}>

--- a/src/ControlPanel.js
+++ b/src/ControlPanel.js
@@ -7,6 +7,18 @@ import styles from './ControlPanel.module.css';
 const min = (a, b) => (a < b ? a : b);
 const max = (a, b) => (a > b ? a : b);
 
+const getFbcnlFromNumbers = (chunk, numbers) => {
+  const index = numbers.indexOf(chunk);
+
+  return [
+    numbers[0],
+    numbers[max(0, index - 1)],
+    chunk,
+    numbers[min(numbers.length - 1, index + 1)],
+    numbers[numbers.length - 1],
+  ];
+};
+
 class ControlPanel extends Component {
   static propTypes = {
     chunks: chunksType.isRequired,
@@ -24,7 +36,11 @@ class ControlPanel extends Component {
   }
 
   getLines() {
-    const { chunks: { start, end } } = this.props;
+    const { chunks: { start, end, numbers } } = this.props;
+
+    if (numbers) {
+      return numbers;
+    }
 
     const lines = [];
     for (let ii = start; ii <= end; ii += 1) {
@@ -35,14 +51,18 @@ class ControlPanel extends Component {
   }
 
   getFbcnl() {
-    const { chunks: { start, end }, match } = this.props;
+    const { chunks: { start, end, numbers }, match } = this.props;
     const { params: { chunk } } = match;
     const index = Number(chunk);
+
+    if (numbers) {
+      return getFbcnlFromNumbers(chunk, numbers);
+    }
 
     return [
       start,
       max(start, index - 1),
-      index,
+      chunk,
       min(end, index + 1),
       end,
     ];

--- a/src/types.js
+++ b/src/types.js
@@ -3,8 +3,9 @@ import {
 } from 'prop-types';
 
 export const chunksType = shape({
-  start: number.isRequired,
-  end: number.isRequired,
+  start: number,
+  end: number,
+  numbers: arrayOf(oneOfType([number, string])),
 });
 
 export const sectionType = shape({


### PR DESCRIPTION
For example, allow: `"chunks": { "numbers": ["1", "2"] }`