### PR TITLE
Add embed view

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,13 +1,17 @@
 import React from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
 import config from '../../config.json';
 
 import Page from '../Page';
+import Embedded from '../Embedded';
 
 const App = () => (
   <Router basename={process.env.PUBLIC_URL}>
-    <Page config={config} />
+    <Switch>
+      <Route path="/embed/" component={() => <Embedded config={config} />} />
+      <Route path="/" component={() => <Page config={config} />} />
+    </Switch>
   </Router>
 );
 

--- a/src/components/Embedded/Embedded.js
+++ b/src/components/Embedded/Embedded.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+
+import { configType } from '../../lib/types';
+
+import EmbeddedPublicationDirector from '../EmbeddedPublicationDirector';
+import EmbeddedNotFound from '../EmbeddedNotFound';
+
+const Embedded = ({ config }) => (
+  <Switch>
+    <Route exact path="/embed/:publication/:chunk" render={(props) => <EmbeddedPublicationDirector {...props} config={config} />} />
+    <Route path="/" component={() => <EmbeddedNotFound config={config} />} />
+  </Switch>
+);
+
+Embedded.propTypes = {
+  config: configType.isRequired,
+};
+
+export default Embedded;

--- a/src/components/Embedded/Embedded.test.js
+++ b/src/components/Embedded/Embedded.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
+
+import Embedded from './Embedded';
+import config from './config.test.json';
+
+it('renders an embedded publication', () => {
+  const component = (
+    <MemoryRouter initialEntries={['/embed/on-the-murder-of-eratosthenes-1-50/1']}>
+      <Embedded config={config} />
+    </MemoryRouter>
+  );
+  const tree = renderer.create(component).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders 404 when publication not found', () => {
+  const component = (
+    <MemoryRouter initialEntries={['/embed/unknown']}>
+      <Embedded config={config} />
+    </MemoryRouter>
+  );
+  const tree = renderer.create(component).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/Embedded/__snapshots__/Embedded.test.js.snap
+++ b/src/components/Embedded/__snapshots__/Embedded.test.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders 404 when publication not found 1`] = `
+<div
+  className="container pt-5"
+>
+  <div
+    className="row col-12 pt-5 pb-3"
+  >
+    <div
+      className="col-12 text-center"
+    >
+      <h1>
+        Error 404
+      </h1>
+    </div>
+  </div>
+  <div
+    className="row col-12 pb-3"
+  >
+    <div
+      className="col-12 text-center"
+    >
+      <h2>
+        Publication not found
+      </h2>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders an embedded publication 1`] = `
+<div>
+  <div
+    className="__artsa"
+  >
+    <div
+      className="treebankContainer"
+      id="treebank_container"
+    />
+  </div>
+  <div
+    className="links"
+  >
+    <a
+      href="/on-the-murder-of-eratosthenes-1-50/1"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Credits and more information
+    </a>
+  </div>
+</div>
+`;

--- a/src/components/Embedded/config.test.json
+++ b/src/components/Embedded/config.test.json
@@ -1,0 +1,1 @@
+../Page/config.test.json

--- a/src/components/Embedded/index.js
+++ b/src/components/Embedded/index.js
@@ -1,0 +1,3 @@
+import Embedded from './Embedded';
+
+export default Embedded;

--- a/src/components/EmbeddedNotFound/EmbeddedNotFound.js
+++ b/src/components/EmbeddedNotFound/EmbeddedNotFound.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const EmbeddedNotFound = () => (
+  <div className="container pt-5">
+    <div className="row col-12 pt-5 pb-3">
+      <div className="col-12 text-center">
+        <h1>Error 404</h1>
+      </div>
+    </div>
+    <div className="row col-12 pb-3">
+      <div className="col-12 text-center">
+        <h2>Publication not found</h2>
+      </div>
+    </div>
+  </div>
+);
+
+export default EmbeddedNotFound;

--- a/src/components/EmbeddedNotFound/index.js
+++ b/src/components/EmbeddedNotFound/index.js
@@ -1,0 +1,3 @@
+import EmbeddedNotFound from './EmbeddedNotFound';
+
+export default EmbeddedNotFound;

--- a/src/components/EmbeddedPublication/EmbeddedPublication.js
+++ b/src/components/EmbeddedPublication/EmbeddedPublication.js
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import { publicationMatchType, locationType } from '../../lib/types';
+
+import ArethusaWrapper from '../ArethusaWrapper';
+import EmbeddedTreebank from '../EmbeddedTreebank';
+
+class EmbeddedPublication extends Component {
+  constructor(props) {
+    super(props);
+
+    this.arethusa = new ArethusaWrapper();
+  }
+
+  render() {
+    const {
+      xml,
+      match,
+      location,
+    } = this.props;
+
+    return (
+      <div>
+        <EmbeddedTreebank
+          xml={xml}
+          location={location}
+          match={match}
+          arethusa={this.arethusa}
+        />
+      </div>
+    );
+  }
+}
+
+EmbeddedPublication.propTypes = {
+  xml: PropTypes.string.isRequired,
+  match: publicationMatchType.isRequired,
+  location: locationType.isRequired,
+};
+
+export default EmbeddedPublication;

--- a/src/components/EmbeddedPublication/index.js
+++ b/src/components/EmbeddedPublication/index.js
@@ -1,0 +1,3 @@
+import EmbeddedPublication from './EmbeddedPublication';
+
+export default EmbeddedPublication;

--- a/src/components/EmbeddedPublicationDirector/EmbeddedPublicationDirector.js
+++ b/src/components/EmbeddedPublicationDirector/EmbeddedPublicationDirector.js
@@ -1,0 +1,48 @@
+import React, { Component } from 'react';
+import { configType, publicationMatchType, locationType } from '../../lib/types';
+
+import EmbeddedPublication from '../EmbeddedPublication';
+import EmbeddedNotFound from '../EmbeddedNotFound';
+
+class EmbeddedPublicationDirector extends Component {
+  constructor(props) {
+    super(props);
+
+    const { config } = props;
+    const argsLookup = {};
+
+    config.collections.forEach((collection) => {
+      (collection.publications || []).forEach((publication) => {
+        publication.sections.forEach((section) => {
+          const { path, xml } = section;
+
+          argsLookup[path] = { xml };
+        });
+      });
+    });
+
+    this.argsLookup = argsLookup;
+  }
+
+  render() {
+    const { config, match, location } = this.props;
+    const { publication } = match.params;
+    const args = this.argsLookup[publication];
+
+    if (args === undefined) {
+      return <EmbeddedNotFound config={config} />;
+    }
+
+    const { xml } = args;
+
+    return <EmbeddedPublication xml={xml} match={match} location={location} />;
+  }
+}
+
+EmbeddedPublicationDirector.propTypes = {
+  config: configType.isRequired,
+  match: publicationMatchType.isRequired,
+  location: locationType.isRequired,
+};
+
+export default EmbeddedPublicationDirector;

--- a/src/components/EmbeddedPublicationDirector/index.js
+++ b/src/components/EmbeddedPublicationDirector/index.js
@@ -1,0 +1,3 @@
+import EmbeddedPublicationDirector from './EmbeddedPublicationDirector';
+
+export default EmbeddedPublicationDirector;

--- a/src/components/EmbeddedTreebank/EmbeddedTreebank.js
+++ b/src/components/EmbeddedTreebank/EmbeddedTreebank.js
@@ -1,0 +1,73 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import queryString from 'query-string';
+
+import { publicationMatchType, locationType } from '../../lib/types';
+
+import styles from './EmbeddedTreebank.module.css';
+
+import ArethusaWrapper from '../ArethusaWrapper';
+
+class EmbeddedTreebank extends Component {
+  constructor(props) {
+    super(props);
+
+    this.additionalArgs = this.additionalArgs.bind(this);
+  }
+
+  componentDidMount() {
+    this.renderArethusa();
+  }
+
+  additionalArgs() {
+    const { location: { search } } = this.props;
+    const parsed = queryString.parse(search);
+    const result = {};
+
+    ['w'].forEach((n) => {
+      if (Object.prototype.hasOwnProperty.call(parsed, n)) {
+        result[n] = parsed[n];
+      }
+    });
+
+    return result;
+  }
+
+  renderArethusa() {
+    const {
+      xml,
+      match: { params: { chunk } },
+      arethusa: { render },
+    } = this.props;
+    const additionalArgs = this.additionalArgs();
+
+    render(xml, chunk, additionalArgs);
+  }
+
+  render() {
+    const { match } = this.props;
+    const { params: { publication, chunk } } = match;
+
+    return (
+      <>
+        <div className="__artsa">
+          <div id="treebank_container" className={styles.treebankContainer} />
+        </div>
+        <div className={styles.links}>
+          <a href={`${process.env.PUBLIC_URL}/${publication}/${chunk}`} target="_blank" rel="noopener noreferrer">
+            Credits and more information
+          </a>
+        </div>
+      </>
+    );
+  }
+}
+
+EmbeddedTreebank.propTypes = {
+  arethusa: PropTypes.instanceOf(ArethusaWrapper).isRequired,
+  match: publicationMatchType.isRequired,
+  location: locationType.isRequired,
+  xml: PropTypes.string.isRequired,
+};
+
+export default EmbeddedTreebank;

--- a/src/components/EmbeddedTreebank/EmbeddedTreebank.module.css
+++ b/src/components/EmbeddedTreebank/EmbeddedTreebank.module.css
@@ -1,0 +1,12 @@
+.treebankContainer {
+  margin-top: 15px !important;
+  margin-bottom: -100px !important;
+  height: calc(100vh - 62px - 5px);
+}
+
+.links {
+  position: absolute;
+  bottom: 3px;
+  width: 100%;
+  text-align: center;
+}

--- a/src/components/EmbeddedTreebank/index.js
+++ b/src/components/EmbeddedTreebank/index.js
@@ -1,0 +1,3 @@
+import EmbeddedTreebank from './EmbeddedTreebank';
+
+export default EmbeddedTreebank;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4557,7 +4557,7 @@ handle-thing@^2.0.0:
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
 handlebars@^4.1.2:
-  version "4.5.2"
+  version "4.5.3"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.2.tgz#5a4eb92ab5962ca3415ac188c86dc7f784f76a0f"
   integrity sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==
   dependencies:


### PR DESCRIPTION
For every treebank, add an "embed" view that can be accessed by visiting `/embed/:publication/:chunk`

For example, `/on-the-murder-of-eratosthenes-1-50/1` in the embed view would be `/embed/on-the-murder-of-eratosthenes-1-50/1`.

This view doesn't have any of the metadata; it just shows the treebank. There is a link at the bottom that links to the full page.

<img width="986" alt="Screen Shot 2019-11-21 at 16 42 58" src="https://user-images.githubusercontent.com/3039310/69379216-0a832180-0c7e-11ea-8e64-f039a06c8652.png">
