### PR TITLE
Do not use morphology service

### DIFF
--- a/src/components/ArethusaWrapper/ArethusaConfig.js
+++ b/src/components/ArethusaWrapper/ArethusaConfig.js
@@ -93,6 +93,7 @@ const defaultConfig = {
       },
       matchAll: true,
       '@include': 'js/arethusa.morph/configs/morph/lat_attributes.json',
+      noRetrieval: 'online',
     },
     search: {
       template: 'js/templates/search.html',


### PR DESCRIPTION
Do not make calls to the morphology service. The morphology will still be displayed to the user if it is in the XML.

Addresses https://github.com/perseids-publications/treebank-template/issues/25