### PR TITLE
GitHub Workflow to create a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g. v1.0.0)'
+        required: true
+      description:
+        description: 'Description of version'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Validate version string
+        run: node scripts/verify-semver.js ${{ github.event.inputs.version }}
+
+      - name: Update package.json
+        run: node scripts/package-json-update-version.js ${{ github.event.inputs.version }}
+
+      - name: Configure git
+        run: bash scripts/configure-git-for-actions.sh
+
+      - name: Create commit
+        run: bash scripts/commit-version-change.sh
+
+      - name: Push changes
+        run: bash scripts/push-to-master.sh
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          commitish: master
+          release_name: Release ${{ github.event.inputs.version }}
+          body: ${{ github.event.inputs.description }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       release:
         description: 'Release (defaults to latest)'
-        required: false
+        required: true
         default: 'source/master'
 
 jobs:

--- a/scripts/commit-version-change.sh
+++ b/scripts/commit-version-change.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This script is used to commit an `package.json` file that has been
+# updated through the `.github/workflows/release.yml` action.
+
+# It adds `package.json` then commits it with a short message
+
+# Add files
+git add package.json
+
+# Commit
+git commit -m "[github actions] bump version"

--- a/scripts/configure-git-for-actions.sh
+++ b/scripts/configure-git-for-actions.sh
@@ -3,7 +3,7 @@
 # This script SHOULD NOT BE RUN LOCALLY
 
 # It configures the git user and email for use in GitHub Actions
-# The reason that this is a script and not in `.github/workflows/update.yml`
+# The reason that this is a script and not in `.github/workflows/*.yml`
 # is that Actions can't update GitHub workflows, so if a change needs to be made
 # in these settings, having them here allows them to be changed.
 

--- a/scripts/package-json-update-version.js
+++ b/scripts/package-json-update-version.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+// This script is used to update the `version` in `package.json`
+// It is used in `.github/workflows/release.yml`.
+
+// It accepts one command line argument: the version number string
+
+const { readFileSync, writeFileSync } = require('fs');
+
+// Read the package.json file
+const packageJson = JSON.parse(
+  readFileSync('package.json', { encoding: 'utf8', flag: 'r' }),
+);
+
+// Get the version number from ARGV and remove `v` from the beginning
+const version = process.argv[2].substr(1);
+
+// Replace the relevant fields
+packageJson.version = version;
+
+// Write to package.json
+writeFileSync('package.json', `${JSON.stringify(packageJson, null, 2)}\n`);

--- a/scripts/push-to-master.sh
+++ b/scripts/push-to-master.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script simply pushes to master. It is used by
-# `.github/workflows/update.yml`.
+# `.github/workflows/update.yml` and `.github/workflows/release.yml`
 
 # The reason that this is a script and not in `.github/workflows/update.yml`
 # is that Actions can't update GitHub workflows, so if a change needs to be made

--- a/scripts/verify-semver.js
+++ b/scripts/verify-semver.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+// This script verifies whether a string matches Semver
+// It is used in `.github/workflows/release.yml`.
+
+// The script accepts the string as a command line argument and
+// exits successfully if it is valid and with an error if it is not valid.
+// Note that the version should be prefixed with `v`.
+// Examples: v1.0.0, v2.33.1, v0.0.4-alpha
+// See https://semver.org/spec/v2.0.0.html for more information and for
+// the source of the regex used here.
+
+// Get the version string from ARGV
+const version = process.argv[2];
+
+// Exit with error if there is no version
+if (version === undefined) {
+  // eslint-disable-next-line no-console
+  console.log('No version provided');
+  process.exit(1);
+}
+
+// Test the string against a Semver regex
+const semver = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+if (!semver.test(version)) {
+  // eslint-disable-next-line no-console
+  console.log('Invalid version: the version must match https://semver.org/spec/v2.0.0.html and be preceded by "v" (e.g. v1.0.0)');
+  process.exit(1);
+}


### PR DESCRIPTION
Addresses https://github.com/perseids-publications/treebank-template/issues/50

This GitHub workflow is triggered by the user and accepts the version number and a description. It updates `package.json`, pushes the changes to `master`, then creates the new release.

I [tested it](https://github.com/zfletch/vg-treebank-display-copy/runs/977468393?check_suite_focus=true) in forked repository and it [created the release](https://github.com/zfletch/vg-treebank-display-copy/releases/tag/v2.0.2).

---

The issue that this PR addresses also mentions Zenodo integration. After learning more about Zenodo, I now think that this can be done with Zenodo's default GitHub integration combined with the release action introduced here. ([Example](https://sandbox.zenodo.org/record/659965))

The biggest problem is that the DOI needs to be pre-registered and the Zenodo GitHub integration doesn't provide that. But Zenodo does provide a DOI that refers to all versions in addition to a DOI for each particular version. I think if we use the DOI for all versions, it would solve that problem, with the only exception being the very first release.