### PR TITLE
Hide treebank navigation links when on page where they irrelevant

### DIFF
--- a/src/components/ControlPanel/ControlPanel.js
+++ b/src/components/ControlPanel/ControlPanel.js
@@ -37,6 +37,8 @@ class ControlPanel extends Component {
     this.toggleRefOpen = this.toggleRefOpen.bind(this);
     this.toggleSettingsOpen = this.toggleSettingsOpen.bind(this);
     this.renderSettingsLinks = this.renderSettingsLinks.bind(this);
+    this.renderBack = this.renderBack.bind(this);
+    this.renderNext = this.renderNext.bind(this);
   }
 
   getLines() {
@@ -109,6 +111,44 @@ class ControlPanel extends Component {
     );
   }
 
+  renderBack(first, back, current) {
+    const visibility = current === String(first) ? ' invisible' : '';
+
+    return (
+      <>
+        <li className={`nav-item${visibility}`}>
+          <Link className={`nav-link text-light ${styles.link}`} to={this.createLink(first)}>
+            &laquo; First
+          </Link>
+        </li>
+        <li className={`nav-item${visibility}`}>
+          <Link className={`nav-link text-light ${styles.link}`} to={this.createLink(back)}>
+            &#8249; Back
+          </Link>
+        </li>
+      </>
+    );
+  }
+
+  renderNext(current, next, last) {
+    const visibility = current === String(last) ? ' invisible' : '';
+
+    return (
+      <>
+        <li className={`nav-item${visibility}`}>
+          <Link className={`nav-link text-light ${styles.link}`} to={this.createLink(next)}>
+            Next &#8250;
+          </Link>
+        </li>
+        <li className={`nav-item${visibility}`}>
+          <Link className={`nav-link text-light ${styles.link}`} to={this.createLink(last)}>
+            Last &raquo;
+          </Link>
+        </li>
+      </>
+    );
+  }
+
   render() {
     const { refIsOpen, settingsIsOpen } = this.state;
     const [first, back, current, next, last] = this.getFbcnl();
@@ -119,16 +159,7 @@ class ControlPanel extends Component {
         <div className="collapse navbar-collapse" id="controlPanel">
           <ul className={`navbar-nav mr-auto ${styles.dummyIcon}`} />
           <ul className="navbar-nav mx-auto">
-            <li className="nav-item">
-              <Link className={`nav-link text-light ${styles.link}`} to={this.createLink(first)}>
-                &laquo; First
-              </Link>
-            </li>
-            <li className="nav-item">
-              <Link className={`nav-link text-light ${styles.link}`} to={this.createLink(back)}>
-                &#8249; Back
-              </Link>
-            </li>
+            {this.renderBack(first, back, current)}
             <li className="nav-item dropdown">
               <button className={`btn btn-link nav-link text-light dropdown-toggle ${styles.dropdownButton}`} type="button" aria-haspopup="true" aria-expanded={refIsOpen} onClick={this.toggleRefOpen}>
                 {current}
@@ -143,16 +174,7 @@ class ControlPanel extends Component {
                 }
               </div>
             </li>
-            <li className="nav-item">
-              <Link className={`nav-link text-light ${styles.link}`} to={this.createLink(next)}>
-                Next &#8250;
-              </Link>
-            </li>
-            <li>
-              <Link className={`nav-link text-light ${styles.link}`} to={this.createLink(last)}>
-                Last &raquo;
-              </Link>
-            </li>
+            {this.renderNext(current, next, last)}
           </ul>
           <ul className="navbar-nav ml-auto">
             <li className="nav-item dropdown dropleft">

--- a/src/components/ControlPanel/ControlPanel.module.css
+++ b/src/components/ControlPanel/ControlPanel.module.css
@@ -20,7 +20,9 @@
 }
 
 @media (min-width: 576px) {
-  width: 34px;
+  .dummyIcon {
+    width: 34px;
+  }
 }
 
 a.link:focus {

--- a/src/components/Page/__snapshots__/Page.test.js.snap
+++ b/src/components/Page/__snapshots__/Page.test.js.snap
@@ -740,7 +740,7 @@ Array [
             className="navbar-nav mx-auto"
           >
             <li
-              className="nav-item"
+              className="nav-item invisible"
             >
               <a
                 className="nav-link text-light link"
@@ -751,7 +751,7 @@ Array [
               </a>
             </li>
             <li
-              className="nav-item"
+              className="nav-item invisible"
             >
               <a
                 className="nav-link text-light link"
@@ -1727,7 +1727,9 @@ Array [
                 Next ›
               </a>
             </li>
-            <li>
+            <li
+              className="nav-item"
+            >
               <a
                 className="nav-link text-light link"
                 href="/on-the-murder-of-eratosthenes-1-50/134"
@@ -2234,7 +2236,7 @@ Array [
             className="navbar-nav mx-auto"
           >
             <li
-              className="nav-item"
+              className="nav-item invisible"
             >
               <a
                 className="nav-link text-light link"
@@ -2245,7 +2247,7 @@ Array [
               </a>
             </li>
             <li
-              className="nav-item"
+              className="nav-item invisible"
             >
               <a
                 className="nav-link text-light link"
@@ -3396,7 +3398,9 @@ Array [
                 Next ›
               </a>
             </li>
-            <li>
+            <li
+              className="nav-item"
+            >
               <a
                 className="nav-link text-light link"
                 href="/philippic-1-51/159"
@@ -3705,7 +3709,7 @@ Array [
             className="navbar-nav mx-auto"
           >
             <li
-              className="nav-item"
+              className="nav-item invisible"
             >
               <a
                 className="nav-link text-light link"
@@ -3716,7 +3720,7 @@ Array [
               </a>
             </li>
             <li
-              className="nav-item"
+              className="nav-item invisible"
             >
               <a
                 className="nav-link text-light link"
@@ -4874,7 +4878,9 @@ Array [
                 Next ›
               </a>
             </li>
-            <li>
+            <li
+              className="nav-item"
+            >
               <a
                 className="nav-link text-light link"
                 href="/on-the-crown-1-50/160"
@@ -5181,7 +5187,7 @@ Array [
             className="navbar-nav mx-auto"
           >
             <li
-              className="nav-item"
+              className="nav-item invisible"
             >
               <a
                 className="nav-link text-light link"
@@ -5192,7 +5198,7 @@ Array [
               </a>
             </li>
             <li
-              className="nav-item"
+              className="nav-item invisible"
             >
               <a
                 className="nav-link text-light link"
@@ -6168,7 +6174,9 @@ Array [
                 Next ›
               </a>
             </li>
-            <li>
+            <li
+              className="nav-item"
+            >
               <a
                 className="nav-link text-light link"
                 href="/on-the-murder-of-eratosthenes-1-50/134?config=sidepanel"
@@ -6475,7 +6483,7 @@ Array [
             className="navbar-nav mx-auto"
           >
             <li
-              className="nav-item"
+              className="nav-item invisible"
             >
               <a
                 className="nav-link text-light link"
@@ -6486,7 +6494,7 @@ Array [
               </a>
             </li>
             <li
-              className="nav-item"
+              className="nav-item invisible"
             >
               <a
                 className="nav-link text-light link"
@@ -7462,7 +7470,9 @@ Array [
                 Next ›
               </a>
             </li>
-            <li>
+            <li
+              className="nav-item"
+            >
               <a
                 className="nav-link text-light link"
                 href="/on-the-murder-of-eratosthenes-1-50/134"
@@ -7759,7 +7769,7 @@ Array [
             className="navbar-nav mx-auto"
           >
             <li
-              className="nav-item"
+              className="nav-item invisible"
             >
               <a
                 className="nav-link text-light link"
@@ -7770,7 +7780,7 @@ Array [
               </a>
             </li>
             <li
-              className="nav-item"
+              className="nav-item invisible"
             >
               <a
                 className="nav-link text-light link"
@@ -8928,7 +8938,9 @@ Array [
                 Next ›
               </a>
             </li>
-            <li>
+            <li
+              className="nav-item"
+            >
               <a
                 className="nav-link text-light link"
                 href="/on-the-crown-1-50/160"


### PR DESCRIPTION
Fixes https://github.com/perseids-publications/treebank-template/issues/55

* When on the last page, don't show the Next and Last links.
* When on the first page, don't show the Previous and First links.

<img width="562" alt="Screen Shot 2020-08-20 at 9 22 20 AM" src="https://user-images.githubusercontent.com/3039310/90778107-3e9d7880-e2ca-11ea-9847-7b8adc761c45.png">

---

<img width="562" alt="Screen Shot 2020-08-20 at 9 22 24 AM" src="https://user-images.githubusercontent.com/3039310/90778123-42c99600-e2ca-11ea-922f-a1a23227b24e.png">
