### PR TITLE
Update README to include getting started steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,20 @@ All other configuration is done using `./src/config.json`.
 
 [https://perseids-publications.github.io/treebank-template/](https://perseids-publications.github.io/treebank-template/)
 
-## How to configure with your own treebanks
+## Get started with your own treebanks
+
+* Getting Started: [https://perseids-publications.github.io/treebank-template/instructions/getting-started/](https://perseids-publications.github.io/treebank-template/instructions/getting-started/)
+* Registering a DOI: [https://perseids-publications.github.io/treebank-template/instructions/doi](https://perseids-publications.github.io/treebank-template/instructions/doi)
+* Updating: [https://perseids-publications.github.io/treebank-template/instructions/updating](https://perseids-publications.github.io/treebank-template/instructions/updating)
+* Alpheios Integration: [https://perseids-publications.github.io/treebank-template/examples/alpheios-integration](https://perseids-publications.github.io/treebank-template/examples/alpheios-integration)
+
+## Technical details
+
+### How to get started using the command line
+
+The *Getting Started* instructions above use the GitHub web interface.
+To create an instance of the Treebank Template with your own trees using the command line,
+follow the steps below:
 
 ```
 git clone git@github.com:perseids-publications/treebank-template.git my-trees
@@ -31,9 +44,9 @@ See [docs/CONFIG.md](docs/CONFIG.md) for more information about the format of `s
 
 ### Updating
 
-#### Manually
-
-The best way to update the code is to use git's built in merging functionality.
+The easiest way to update the Treebank Template code is to follow the instructions
+in the *Updating* link above.
+Alternatively, you can use Git's built in merging functionality.
 A typical update may involve the following steps:
 
 * `git pull source master --no-commit` (if there is no `source` repository, then run
@@ -55,30 +68,15 @@ git checkout --ours src/config.json
 * `git commit`
 * `git push origin master`
 
-#### GitHub Actions
-
-There is an experimental workflow that updates the code automatically.
-Instead of `git merge`, it uses `git restore --source`. For more information
-about the technical aspects, see
-[.github/workflows/update.yml](.github/workflows/update.yml) and the files in
-[scripts/](scripts/).
-
-To use this workflow:
-
-1. Click the "Actions" on the top of the repository on GitHub
-2. Click "update" under the list of workfows
-3. Click "Run workflow" and then either click the green "Run workflow" button
-   or enter the tag you'd like to use (e.g. `3.2.0`) then click the button.
-
-## Installation
+### Installation
 
 `yarn install`
 
-## Running the development server
+### Running the development server
 
 `yarn start`
 
-## Building for deployment
+### Building for deployment
 
 Before creating a production build you need to know the path where it will be accessed.
 Then run the command `PUBLIC_URL='./path/of/app' yarn build`.
@@ -88,37 +86,37 @@ For example, if you want to deploy it at `www.example.com/` then run `PUBLIC_URL
 If you want to deploy it at `www.example.com/lexica/lsj` then run
 `PUBLIC_URL='./lexica/lsj' yarn build`.
 
-## Deploying a new version to github.io
+### Deploying a new version to github.io
 
 `yarn deploy`
 
-## Zenodo DOI
+### Zenodo DOI
 
-The instructions below are for uploading a collection of treebanks to Zenodo.
-The Treebank Template repository itself is uploaded to Zenodo but the steps are slightly different
-(the version of the Treebank Template application is used for the version, the upload type is software, the contributors are different, and the license is MIT instead of CC BY-SA)
+The easiest way to register a DOI and add it to your collection of treebanks is to follow
+the instructions in the *Registering a DOI* link above.
+The instructions below explain an alternative method that is more complicated but more configurarable.
 
-### Zenodo
+#### Zenodo
 
 * Visit [Zenodo](https://zenodo.org/deposit/new), log in, and create a new upload
 * Click the "Reserve DOI" button in the "Basic information" section
 * Keeping the window open, open your command line/console and navigate to the repository
 
-### Git
+#### Git
 
 * In `src/config.json`, add or update the `doi` field to the DOI generated in the above step (preceded by `https://dx.doi.org/`)
 * Update the version in `package.json` (try to use [SemVer](https://semver.org/))
 * Push the code to `master`
 * Keeping the Zenodo window open, in another tab or window open the repository on GitHub
 
-### GitHub
+#### GitHub
 
 * Make a new release titled "Release vA.B.C" where "A.b.C" is the version in `package.json` and use the same string ("vA.B.C") in the "Tag Version" field
 * Enter a description then click "Publish release"
 * Download the release as a `tar.gz` file
 * Go back to the Zenodo window or tab
 
-### Zenodo
+#### Zenodo
 
 * Add the `tar.gz` file to the upload
 * Fill in the following fields:
@@ -134,10 +132,6 @@ The Treebank Template repository itself is uploaded to Zenodo but the steps are 
     * License: Creative Commons Attribution 4.0 International
   * Fill in any other fields that are relevant
 * Click "Publish"
-
-## Alpheios Integration
-
-For instructions on how to make your trees available in the [Alpheios Reading Tools](https://alpheios.net) visit [https://perseids-publications.github.io/treebank-template/examples/alpheios-integration](https://perseids-publications.github.io/treebank-template/examples/alpheios-integration).
 
 ## Licenses
 


### PR DESCRIPTION
* Add a section that links to all of the pages within `/instructions` and `/examples`.
* Move the other instructions under  `## Technical details`.
* Update some of the language to direct people to `/instructions/whatever` at the beginning of each technical section.