### PR TITLE
Support Treebank Rendering with Treebank React

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "arethusa-widget": "^2.1.3",
     "bootstrap": "^4.5.0",
     "cp-cli": "^2.0.0",
+    "cross-fetch": "^3.0.6",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-plugin-jest": "^23.20.0",
     "gh-pages": "^3.1.0",
@@ -24,7 +25,8 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",
     "react-test-renderer": "^16.13.1",
-    "reactstrap": "^8.5.1"
+    "reactstrap": "^8.5.1",
+    "treebank-react": "^0.2.1"
   },
   "scripts": {
     "predeploy": "yarn run build",

--- a/src/components/Embedded/__snapshots__/Embedded.test.js.snap
+++ b/src/components/Embedded/__snapshots__/Embedded.test.js.snap
@@ -14,7 +14,7 @@ exports[`provides an API to communicate with an embedded publication 1`] = `
     className="links"
   >
     <a
-      href="/on-the-murder-of-eratosthenes-1-50/5"
+      href="https://www.example.com/on-the-murder-of-eratosthenes-1-50/5"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -22,27 +22,27 @@ exports[`provides an API to communicate with an embedded publication 1`] = `
     </a>
   </div>
   <link
-    href="/arethusa/css/arethusa.min.css"
+    href="https://www.example.com/arethusa/css/arethusa.min.css"
     rel="stylesheet"
     type="text/css"
   />
   <link
-    href="/arethusa/css/colorpicker.css"
+    href="https://www.example.com/arethusa/css/colorpicker.css"
     rel="stylesheet"
     type="text/css"
   />
   <link
-    href="/arethusa/css/font-awesome.min.css"
+    href="https://www.example.com/arethusa/css/font-awesome.min.css"
     rel="stylesheet"
     type="text/css"
   />
   <link
-    href="/arethusa/css/foundation-icons.css"
+    href="https://www.example.com/arethusa/css/foundation-icons.css"
     rel="stylesheet"
     type="text/css"
   />
   <link
-    href="/arethusa/css/widget.css"
+    href="https://www.example.com/arethusa/css/widget.css"
     rel="stylesheet"
     type="text/css"
   />
@@ -92,7 +92,7 @@ exports[`renders an embedded publication 1`] = `
     className="links"
   >
     <a
-      href="/on-the-murder-of-eratosthenes-1-50/1"
+      href="https://www.example.com/on-the-murder-of-eratosthenes-1-50/1"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -100,27 +100,27 @@ exports[`renders an embedded publication 1`] = `
     </a>
   </div>
   <link
-    href="/arethusa/css/arethusa.min.css"
+    href="https://www.example.com/arethusa/css/arethusa.min.css"
     rel="stylesheet"
     type="text/css"
   />
   <link
-    href="/arethusa/css/colorpicker.css"
+    href="https://www.example.com/arethusa/css/colorpicker.css"
     rel="stylesheet"
     type="text/css"
   />
   <link
-    href="/arethusa/css/font-awesome.min.css"
+    href="https://www.example.com/arethusa/css/font-awesome.min.css"
     rel="stylesheet"
     type="text/css"
   />
   <link
-    href="/arethusa/css/foundation-icons.css"
+    href="https://www.example.com/arethusa/css/foundation-icons.css"
     rel="stylesheet"
     type="text/css"
   />
   <link
-    href="/arethusa/css/widget.css"
+    href="https://www.example.com/arethusa/css/widget.css"
     rel="stylesheet"
     type="text/css"
   />
@@ -141,7 +141,7 @@ exports[`the API can be used to select words 1`] = `
     className="links"
   >
     <a
-      href="/on-the-murder-of-eratosthenes-1-50/5"
+      href="https://www.example.com/on-the-murder-of-eratosthenes-1-50/5"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -149,27 +149,27 @@ exports[`the API can be used to select words 1`] = `
     </a>
   </div>
   <link
-    href="/arethusa/css/arethusa.min.css"
+    href="https://www.example.com/arethusa/css/arethusa.min.css"
     rel="stylesheet"
     type="text/css"
   />
   <link
-    href="/arethusa/css/colorpicker.css"
+    href="https://www.example.com/arethusa/css/colorpicker.css"
     rel="stylesheet"
     type="text/css"
   />
   <link
-    href="/arethusa/css/font-awesome.min.css"
+    href="https://www.example.com/arethusa/css/font-awesome.min.css"
     rel="stylesheet"
     type="text/css"
   />
   <link
-    href="/arethusa/css/foundation-icons.css"
+    href="https://www.example.com/arethusa/css/foundation-icons.css"
     rel="stylesheet"
     type="text/css"
   />
   <link
-    href="/arethusa/css/widget.css"
+    href="https://www.example.com/arethusa/css/widget.css"
     rel="stylesheet"
     type="text/css"
   />

--- a/src/components/Page/Page.test.js
+++ b/src/components/Page/Page.test.js
@@ -238,3 +238,18 @@ it('renders 404 when no instruction route matches', () => {
 
   expect(tree).toMatchSnapshot();
 });
+
+it('renders differently when treebankReact is set', () => {
+  config.treebankReact = true;
+
+  const component = (
+    <MemoryRouter initialEntries={['/on-the-murder-of-eratosthenes-1-50/1']}>
+      <Page config={config} />
+    </MemoryRouter>
+  );
+  const tree = renderer.create(component).toJSON();
+
+  expect(tree).toMatchSnapshot();
+
+  delete config.treebankReact;
+});

--- a/src/components/Page/__snapshots__/Page.test.js.snap
+++ b/src/components/Page/__snapshots__/Page.test.js.snap
@@ -27,7 +27,7 @@ Array [
       >
         <a
           className="nav-link"
-          href="/"
+          href="https://www.example.com/"
         >
           Home
         </a>
@@ -67,7 +67,7 @@ Array [
       >
         <h2>
           <a
-            href="/"
+            href="https://www.example.com/"
           >
             Return to homepage
           </a>
@@ -173,7 +173,7 @@ Array [
       >
         <a
           className="nav-link"
-          href="/"
+          href="https://www.example.com/"
         >
           Home
         </a>
@@ -213,7 +213,7 @@ Array [
       >
         <h2>
           <a
-            href="/"
+            href="https://www.example.com/"
           >
             Return to homepage
           </a>
@@ -319,7 +319,7 @@ Array [
       >
         <a
           className="nav-link"
-          href="/"
+          href="https://www.example.com/"
         >
           Home
         </a>
@@ -359,7 +359,7 @@ Array [
       >
         <h2>
           <a
-            href="/"
+            href="https://www.example.com/"
           >
             Return to homepage
           </a>
@@ -465,7 +465,7 @@ Array [
       >
         <a
           className="nav-link"
-          href="/"
+          href="https://www.example.com/"
         >
           Home
         </a>
@@ -505,7 +505,7 @@ Array [
       >
         <h2>
           <a
-            href="/"
+            href="https://www.example.com/"
           >
             Return to homepage
           </a>
@@ -611,7 +611,7 @@ Array [
       >
         <a
           className="nav-link"
-          href="/"
+          href="https://www.example.com/"
         >
           Home
         </a>
@@ -651,7 +651,7 @@ Array [
       >
         <h2>
           <a
-            href="/"
+            href="https://www.example.com/"
           >
             Return to homepage
           </a>
@@ -759,7 +759,7 @@ Array [
       >
         <a
           className="nav-link"
-          href="/"
+          href="https://www.example.com/"
         >
           Home
         </a>
@@ -1943,27 +1943,27 @@ Array [
         />
       </div>
       <link
-        href="/arethusa/css/arethusa.min.css"
+        href="https://www.example.com/arethusa/css/arethusa.min.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/colorpicker.css"
+        href="https://www.example.com/arethusa/css/colorpicker.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/font-awesome.min.css"
+        href="https://www.example.com/arethusa/css/font-awesome.min.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/foundation-icons.css"
+        href="https://www.example.com/arethusa/css/foundation-icons.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/widget.css"
+        href="https://www.example.com/arethusa/css/widget.css"
         rel="stylesheet"
         type="text/css"
       />
@@ -1972,11 +1972,11 @@ Array [
       className="pt-1 pb-4 text-right"
     >
       <a
-        href="/xml/lysias-1-1-50.xml"
+        href="https://www.example.com/xml/lysias-1-1-50.xml"
         rel="noopener noreferrer"
         target="_blank"
       >
-        View XML
+        View full XML
       </a>
     </div>
   </div>,
@@ -2076,7 +2076,7 @@ Array [
       >
         <a
           className="nav-link"
-          href="/"
+          href="https://www.example.com/"
         >
           Home
         </a>
@@ -2299,7 +2299,7 @@ Array [
       >
         <a
           className="nav-link"
-          href="/"
+          href="https://www.example.com/"
         >
           Home
         </a>
@@ -3639,27 +3639,27 @@ Array [
         />
       </div>
       <link
-        href="/arethusa/css/arethusa.min.css"
+        href="https://www.example.com/arethusa/css/arethusa.min.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/colorpicker.css"
+        href="https://www.example.com/arethusa/css/colorpicker.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/font-awesome.min.css"
+        href="https://www.example.com/arethusa/css/font-awesome.min.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/foundation-icons.css"
+        href="https://www.example.com/arethusa/css/foundation-icons.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/widget.css"
+        href="https://www.example.com/arethusa/css/widget.css"
         rel="stylesheet"
         type="text/css"
       />
@@ -3668,11 +3668,11 @@ Array [
       className="pt-1 pb-4 text-right"
     >
       <a
-        href="/xml/demosthenes-4-phil1-bu1.xml"
+        href="https://www.example.com/xml/demosthenes-4-phil1-bu1.xml"
         rel="noopener noreferrer"
         target="_blank"
       >
-        View XML
+        View full XML
       </a>
     </div>
   </div>,
@@ -3776,7 +3776,7 @@ Array [
       >
         <a
           className="nav-link"
-          href="/"
+          href="https://www.example.com/"
         >
           Home
         </a>
@@ -5144,27 +5144,27 @@ Array [
         />
       </div>
       <link
-        href="/arethusa/css/arethusa.min.css"
+        href="https://www.example.com/arethusa/css/arethusa.min.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/colorpicker.css"
+        href="https://www.example.com/arethusa/css/colorpicker.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/font-awesome.min.css"
+        href="https://www.example.com/arethusa/css/font-awesome.min.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/foundation-icons.css"
+        href="https://www.example.com/arethusa/css/foundation-icons.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/widget.css"
+        href="https://www.example.com/arethusa/css/widget.css"
         rel="stylesheet"
         type="text/css"
       />
@@ -5173,11 +5173,11 @@ Array [
       className="pt-1 pb-4 text-right"
     >
       <a
-        href="/xml/demosthenes-18-1-50.xml"
+        href="https://www.example.com/xml/demosthenes-18-1-50.xml"
         rel="noopener noreferrer"
         target="_blank"
       >
-        View XML
+        View full XML
       </a>
     </div>
   </div>,
@@ -5281,7 +5281,7 @@ Array [
       >
         <a
           className="nav-link"
-          href="/"
+          href="https://www.example.com/"
         >
           Home
         </a>
@@ -6465,27 +6465,27 @@ Array [
         />
       </div>
       <link
-        href="/arethusa/css/arethusa.min.css"
+        href="https://www.example.com/arethusa/css/arethusa.min.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/colorpicker.css"
+        href="https://www.example.com/arethusa/css/colorpicker.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/font-awesome.min.css"
+        href="https://www.example.com/arethusa/css/font-awesome.min.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/foundation-icons.css"
+        href="https://www.example.com/arethusa/css/foundation-icons.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/widget.css"
+        href="https://www.example.com/arethusa/css/widget.css"
         rel="stylesheet"
         type="text/css"
       />
@@ -6494,11 +6494,11 @@ Array [
       className="pt-1 pb-4 text-right"
     >
       <a
-        href="/xml/lysias-1-1-50.xml"
+        href="https://www.example.com/xml/lysias-1-1-50.xml"
         rel="noopener noreferrer"
         target="_blank"
       >
-        View XML
+        View full XML
       </a>
     </div>
   </div>,
@@ -6602,7 +6602,7 @@ Array [
       >
         <a
           className="nav-link"
-          href="/"
+          href="https://www.example.com/"
         >
           Home
         </a>
@@ -7786,27 +7786,27 @@ Array [
         />
       </div>
       <link
-        href="/arethusa/css/arethusa.min.css"
+        href="https://www.example.com/arethusa/css/arethusa.min.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/colorpicker.css"
+        href="https://www.example.com/arethusa/css/colorpicker.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/font-awesome.min.css"
+        href="https://www.example.com/arethusa/css/font-awesome.min.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/foundation-icons.css"
+        href="https://www.example.com/arethusa/css/foundation-icons.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/widget.css"
+        href="https://www.example.com/arethusa/css/widget.css"
         rel="stylesheet"
         type="text/css"
       />
@@ -7815,11 +7815,11 @@ Array [
       className="pt-1 pb-4 text-right"
     >
       <a
-        href="/xml/lysias-1-1-50.xml"
+        href="https://www.example.com/xml/lysias-1-1-50.xml"
         rel="noopener noreferrer"
         target="_blank"
       >
-        View XML
+        View full XML
       </a>
     </div>
   </div>,
@@ -7923,7 +7923,7 @@ Array [
       >
         <a
           className="nav-link"
-          href="/"
+          href="https://www.example.com/"
         >
           Home
         </a>
@@ -9279,27 +9279,27 @@ Array [
         />
       </div>
       <link
-        href="/arethusa/css/arethusa.min.css"
+        href="https://www.example.com/arethusa/css/arethusa.min.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/colorpicker.css"
+        href="https://www.example.com/arethusa/css/colorpicker.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/font-awesome.min.css"
+        href="https://www.example.com/arethusa/css/font-awesome.min.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/foundation-icons.css"
+        href="https://www.example.com/arethusa/css/foundation-icons.css"
         rel="stylesheet"
         type="text/css"
       />
       <link
-        href="/arethusa/css/widget.css"
+        href="https://www.example.com/arethusa/css/widget.css"
         rel="stylesheet"
         type="text/css"
       />
@@ -9308,11 +9308,240 @@ Array [
       className="pt-1 pb-4 text-right"
     >
       <a
-        href="/xml/demosthenes-18-1-50.xml"
+        href="https://www.example.com/xml/demosthenes-18-1-50.xml"
         rel="noopener noreferrer"
         target="_blank"
       >
-        View XML
+        View full XML
+      </a>
+    </div>
+  </div>,
+  <footer
+    className="footer perseids-react-components--footer"
+  >
+    <nav
+      className="navbar navbar-light bg-light py-0 perseids-react-components--footer-nav"
+    >
+      <span
+        className="navbar-text"
+      >
+        © The Perseids Project 2019
+      </span>
+      <ul
+        className="navbar-nav my-2 my-lg-02 flex-row"
+      >
+        <li
+          className="nav-item"
+        >
+          <a
+            className="nav-link py-2 pl-1 pl-sm-2 pr-1 pr-sm-2"
+            href="https://github.com/perseids-publications/treebank-template/issues"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Report Icon"
+              className="perseids-react-components--octicon"
+              src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDE2IDE2Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xLjc1IDEuNWEuMjUuMjUgMCAwMC0uMjUuMjV2OS41YzAgLjEzOC4xMTIuMjUuMjUuMjVoMmEuNzUuNzUgMCAwMS43NS43NXYyLjE5bDIuNzItMi43MmEuNzUuNzUgMCAwMS41My0uMjJoNi41YS4yNS4yNSAwIDAwLjI1LS4yNXYtOS41YS4yNS4yNSAwIDAwLS4yNS0uMjVIMS43NXpNMCAxLjc1QzAgLjc4NC43ODQgMCAxLjc1IDBoMTIuNUMxNS4yMTYgMCAxNiAuNzg0IDE2IDEuNzV2OS41QTEuNzUgMS43NSAwIDAxMTQuMjUgMTNIOC4wNmwtMi41NzMgMi41NzNBMS40NTcgMS40NTcgMCAwMTMgMTQuNTQzVjEzSDEuNzVBMS43NSAxLjc1IDAgMDEwIDExLjI1di05LjV6TTkgOWExIDEgMCAxMS0yIDAgMSAxIDAgMDEyIDB6bS0uMjUtNS4yNWEuNzUuNzUgMCAwMC0xLjUgMHYyLjVhLjc1Ljc1IDAgMDAxLjUgMHYtMi41eiIvPjwvc3ZnPg=="
+              title="Report Issue"
+            />
+          </a>
+        </li>
+        <li
+          className="nav-item"
+        >
+          <a
+            className="nav-link py-2 pl-1 pl-sm-2 pr-1 pr-sm-2"
+            href="https://github.com/perseids-publications/treebank-template/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="GitHub Icon"
+              className="perseids-react-components--octicon"
+              src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDE2IDE2Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik04IDBDMy41OCAwIDAgMy41OCAwIDhjMCAzLjU0IDIuMjkgNi41MyA1LjQ3IDcuNTkuNC4wNy41NS0uMTcuNTUtLjM4IDAtLjE5LS4wMS0uODItLjAxLTEuNDktMi4wMS4zNy0yLjUzLS40OS0yLjY5LS45NC0uMDktLjIzLS40OC0uOTQtLjgyLTEuMTMtLjI4LS4xNS0uNjgtLjUyLS4wMS0uNTMuNjMtLjAxIDEuMDguNTggMS4yMy44Mi43MiAxLjIxIDEuODcuODcgMi4zMy42Ni4wNy0uNTIuMjgtLjg3LjUxLTEuMDctMS43OC0uMi0zLjY0LS44OS0zLjY0LTMuOTUgMC0uODcuMzEtMS41OS44Mi0yLjE1LS4wOC0uMi0uMzYtMS4wMi4wOC0yLjEyIDAgMCAuNjctLjIxIDIuMi44Mi42NC0uMTggMS4zMi0uMjcgMi0uMjcuNjggMCAxLjM2LjA5IDIgLjI3IDEuNTMtMS4wNCAyLjItLjgyIDIuMi0uODIuNDQgMS4xLjE2IDEuOTIuMDggMi4xMi41MS41Ni44MiAxLjI3LjgyIDIuMTUgMCAzLjA3LTEuODcgMy43NS0zLjY1IDMuOTUuMjkuMjUuNTQuNzMuNTQgMS40OCAwIDEuMDctLjAxIDEuOTMtLjAxIDIuMiAwIC4yMS4xNS40Ni41NS4zOEE4LjAxMyA4LjAxMyAwIDAwMTYgOGMwLTQuNDItMy41OC04LTgtOHoiLz48L3N2Zz4="
+              title="View Source on Github"
+            />
+          </a>
+        </li>
+        <li
+          className="nav-item"
+        >
+          <a
+            className="nav-link py-2 pl-1 pl-sm-2 pr-0"
+            href="https://twitter.com/PerseidsProject"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Twitter Icon"
+              className="perseids-react-components--twitter"
+              src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHJlY3QgaGVpZ2h0PSIyNCIgd2lkdGg9IjI0IiBmaWxsPSJub25lIiB4PSIwIi8+CiAgPGc+CiAgIDxwYXRoIGlkPSJzdmdfMyIgZD0ibTIwLjAxMTI1LDMuNzk5Yy0wLjczNiwwLjMyNiAtMS41MjcsMC41NDcgLTIuMzU3LDAuNjQ2YzAuODQ3LC0wLjUwOCAxLjQ5OCwtMS4zMTIgMS44MDQsLTIuMjdjLTAuNzkzLDAuNDcgLTEuNjcsMC44MTIgLTIuNjA2LDAuOTk2Yy0wLjc0NiwtMC43OTggLTEuODEzLC0xLjI5NiAtMi45OTMsLTEuMjk2Yy0yLjI2NiwwIC00LjEwMywxLjgzNyAtNC4xMDMsNC4xMDNjMCwwLjMyMiAwLjAzNiwwLjYzNSAwLjEwNiwwLjkzNWMtMy40MSwtMC4xNyAtNi40MzMsLTEuODA0IC04LjQ1NywtNC4yODdjLTAuMzUzLDAuNjA3IC0wLjU1NiwxLjMxMiAtMC41NTYsMi4wNjRjMCwxLjQyNCAwLjcyNCwyLjY4IDEuODI1LDMuNDE1Yy0wLjY3MywtMC4wMjIgLTEuMzA1LC0wLjIwNyAtMS44NiwtMC41MTRsMCwwLjA1MmMwLDEuOTg4IDEuNDE1LDMuNjQ3IDMuMjkzLDQuMDIzYy0wLjM0NCwwLjA5NSAtMC43MDcsMC4xNDUgLTEuMDgsMC4xNDVjLTAuMjY1LDAgLTAuNTIyLC0wLjAyNiAtMC43NzMsLTAuMDc0YzAuNTIyLDEuNjMgMi4wMzgsMi44MTcgMy44MzMsMi44NWMtMS40MDQsMS4xIC0zLjE3NCwxLjc1NyAtNS4wOTYsMS43NTdjLTAuMzMyLDAgLTAuNjYsLTAuMDIgLTAuOTgsLTAuMDU3YzEuODE2LDEuMTY0IDMuOTczLDEuODQzIDYuMjksMS44NDNjNy41NDcsMCAxMS42NzUsLTYuMjUyIDExLjY3NSwtMTEuNjc1YzAsLTAuMTc4IC0wLjAwNCwtMC4zNTUgLTAuMDEyLC0wLjUzYzAuODAyLC0wLjU3OCAxLjQ5NywtMS4zIDIuMDQ3LC0yLjEyNGwwLC0wLjAwMnoiLz4KIDwvZz4KPC9zdmc+Cg=="
+              title="Twitter"
+            />
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </footer>,
+]
+`;
+
+exports[`renders differently when treebankReact is set 1`] = `
+Array [
+  <header
+    className="navbar navbar-expand-md navbar-light bg-light perseids-react-components--navbar"
+  >
+    <a
+      className="navbar-brand perseids-react-components--navbar-brand"
+      href="https://www.perseids.org"
+    >
+      <img
+        alt="perseids logo"
+        className="perseids-react-components--navbar-logo-img"
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZYAAAFxCAYAAABQuY6sAAAAB3RJTUUH4gQeARwUL3F1UgAAAAFvck5UAc+id5oAAIAASURBVHja7b17fBzFmS78VPX0jGYkjWxLtuWLfL+BjLEBm2Cu4ZIYErMJbEKyIQlkA8nCSeBs2D3J+ZZkD9ndsJvkbLIb2CzJOSR7YBNIIAlOwFwXkwCJDbEBC3zBV/kiX2RbsjTSXLrr+6NvVdXVMyNp5JHken4/qWuqqy/T011PP+/71luEMQYNDQ0NDY1KgVb7BDQ0NDQ0xhY0sWhoaGhoVBSaWDQ0NDQ0KgpNLBoaGhoaFYUmFg0NDQ2NikITi4aGhoZGRaGJRUNDQ0OjotDEoqGhoaFRUWhi0dDQ0NCoKDSxaGhoaGhUFJpYNDQ0NDQqCk0sGhoaGhoVhSYWDQ0NDY2KQhOLhoaGhkZFoYlFQ0NDQ6Oi0MSioaGhoVFRaGLR0NDQ0KgoNLFoaGhoaFQUmlg0NDQ0NCoKTSwaGhoaGhWFJhYNDQ0NjYpCE4uGhoaGRkWhiUVDQ0NDo6LQxKKhoaGhUVFoYtHQ0NDQqCg0sWhoaGhoVBSaWDQ0NDQ0KgpNLBoaGhoaFYUmFg0NDQ2NikITi4aGhoZGRRGr9gloaIxEZDJofWcrW3XoMJu+ew+b9VYbm9/dhdrfvmLPqq0FzjuH7lwwj7TPnEHaZ7Rgz9w5ZOO0qWQtpeit9rlraFQbhDFW7XPQ0BgRsG2kjxxhK9/czC5/8y37rGees1dl+oDeXobuk0ChAIABIAClQG0KqK0lqKsFxo8n+NC19MdnL6Hr584mLyST2FLt76OhUS1oYtE47dF9Eue99ZZ9zbrfWpc+/kvr8sOHGQhx1g1sSUAI8IFrjI2XXUxfXbqUrps5gzxa7e+noXGqoYlF47SFbSP95lv2Z/76y7mvbtlqjycEcPkBLl8IxCGs45Z+O8W6e74W/+EHrol9J5VCW7W/r4bGqYImFo3TEsePs4v+/h9y//yzxwrnOZzAQsQwONUCEL/g1E2bSo7/8/+u+cqZZ9J/r/b31tA4FdDEonHa4fHH89//0l39nwNTKRKmVCalyASERCoaAoAaxLruOvN3//N/Jj5sGDhe7WugoTGc0MSicVrhe/+afeJ738uuzueYkjQCnmB+nbAu9JkE7ZRmMhLsgwJXXGG+9o17kx+MxXCo2tdCQ2O4oIlF47TBN/+x75kfP5i9KpsFABbpNwnIJJpcCOeIKapipDpqELz3cvO1e76evCFRQ3ZW+5poaAwHNLFonBa452uZ3/7k4f6LLMsjjwiTl1DHIsxgpLgT32sj75/bYOVF5pv3frP2w4mEJheNsQdNLBpjHk/+Ovsvf/nfTn5BJA+mNoORgHgAlBVezNeLRCKTi2g2u+aDid/9zf+qu7ja10dDo9LQxKIxprF/n/Wha9937Bd9GRZy0HP9vltmRcOK1UtSlkNfZT5L1JC+r/59+n9fcln8b6p9nTQ0KglNLBpjFv39bP5ff7HriRee6V+kIg/elzKYSDBZvSjNYzy5IDCjeeX6NOn+wUMTbmyeaqyp9vXS0KgUdBJKjTGLXz6a+eqLz2QWGbBhEAsGLBjEhgHnj8Ktgw2KoH6gf862zn68/VMir3fWUWm7zEkr/f9+2POlXI61VPt6aWhUCppYNMYkdmzL3/yv/9h1o8F1+gJ5EKsIWTiEExCP/Mfvh18q1ktkJhKQBQobz6zpvfTN13OfqvY109CoFHR2Y40xiWfWZD7a31uAAeY77AlchzzElC38qHvOBy+2jfKxuK2E7STHvtCCiO29HT37694PnHGWuaa2jr5Z7WunoTFUaMWiMeawb0/ho88+cfJilTqQVUlxBcKZ0FBa4YSVSbANFRSSey4kUDAvP99zwbvv5N5f7WunoVEJaMWiMeaw7umej3bszdYacNRIoFgAhD4HbQCFUim5JIJ6IfJ/oqj1xQu3FQM2/7H//CXn1SQJQV+1r6GGxlCgFYvGmIJtI/3WhkwrtS3EYEm+Dqu0YoHtblfCt8IpjlhoffhYMUmhiP4Xp+7px7uuP7Q/r1WLxqiHViwaYwq7tmU/+vbrTiRY2K8ihhXLSqWkahmAf4Xfjx9yzNfyda4zpq/Lxtub+i5vnm7+strXUUNjKNDEojGm8Nu13R/OnMgVcdoH9eJ4lRKDIyNStggj7kPjWXiTmMp5H6ayPdv65wPpal9GDY0hQROLxpjCW6/2nAXLguFGewWDIYMULapcYSJxSCRTjEz8Nur0LfK6IFpMPQrzxOHchL5ee0myVkeHaYxeaGLRGDMo5NnUnhO5uhixQqlbiEKRFCcXd7tiucDcFeF10aQipHZRHHDbpp4VRw7kls2YX6OJRWPUQhOLxpjBscP5FSePZscbsCKUSel0LkJfP4A8YXIuMHEdr3SiSYUQIN/H0LE3u2jG/JpqX04NjUFDE4vGmMHxI/lZrOBEWgUkIpNJmeRSlFSIYCIrm1Qiko0RXkoVbBxu758JNFT7cmpoDBqaWDTGDDoPZGeiUEAMlk8WYTKJUihcfTGFwrWBv44bmyLsNNrsRQR7m3iwrqO58dW+lhoaQ4EmFo0xg0x3voHaBUmxQCIZ1edo9SIoFO9zGaSiNnvx7aPlkZUtxKt9LTU0hgJNLBpjBpmufJowZzAibwaTzV9CbjBlKHHpsGMV4ahJxSkT1Q5VDh1CANs2qn0tNTSGAk0sGmMGMYNZMVgAsUNKJSAZ6bOij48ik+ITeYnzrgR+lgiW8ts7o2wIIWBunUGZVe1rqaExFGhi0RgzqEnRPtOwgbwlkEdU6HGlSEUkEMkZH3LiSztXHNAgdrUvpYbGkKCJRWPMoH5c7HiM2rDdcSyk2DiWEnPeFyMVcRZIfiNxHa9KlAdRhZ8RgkSC5Kp9LTU0hgJNLBpjBuMnxQ8kYjZshBWLMPJe5WcBBkkqCJnE/HZSnSyTCAAWkk4E4ybFj1b7WmpoDAWaWDTGDMZNTuyMxxnykmIRBkcqTGOARC6KOu+zcg57fzuOTBS+lOIHcgkpRtE4tWZfta+lhsZQoIlFY8ygbnx85/im2NH+Y5kmlWIRlQmL7OujfO6CX8Wr8yK+pBWqukhpxJXjCYqGifED1b6WGhpDgSYWjTGDmrrYxvoGo+cIsZpkH4vovJdMY0BJUglnLnb+8QQijLZX7IhEmMQY1y6ZMjFucs32al9LDY2hQBOLxphCutHs9kbeA56VSSYVQJXBuBSpKJNN8mV33UDNXzzRLHxP09q6CQmdgFJjVEMTi8YpQ29XYUU2U2jqO1mY3Hmgfy41YFFKrNqG2NG6cfEDdY3xLYmksWUox5i1dMKWrc/vXcJsmyOTEpmNS5JKoDYEhz1HNIF6UXj9BbXjjFeJIpracWa3YdIhmcJ6j+duOXE4u7yvO998dF9fKwhgFWBOmFqzrXZcvD2RMjonTKlZYybouuH9xTVOV2hi0RhWHOvIXtO+5eTKnRu7lr3z+2NnHdnT25LPFJDpyoFSBoMwJJIUyToDs88et2XKvLr2qQvT22efM+GFppbaxwZ6vDnLm35XW0c/2t+dL28ulghSESOBZVKRnPbSKHuxTm3+ksvM3XbC1OSgSCXXb83v3Nt70YmOvlkbntj31Ux3HvksQ19PASAUDECi1myJJQzEEgbqmxJfmjK3rnPO2Q1rm+fUPl5TazxepVtEYwyCMMaqfQ4aYxAduzIf//2vD338hf+39/2d+zJxCgZCGCgYKGEgYKBuTi/qqoqgniGVjuGDf3XWQ4suaV4zflpqnRGjh8o5br6/MP/RL774xI7f7lsUiggD38+zMkmFIwluncqnos4DBpRrCoslY/jId99708R5435c7nXu78kvO7Lz5EVbf9dx+RtP7f8Q3BH8gLQUytT16xDEUzE0z6vDkssmrltw3rh740ljbbXvHY3RD00sGhWFVWBNrz7R8Xf33/7G5whsUJdMwqTC4K0ngFQfLAlheM/H5736no/Pf2jy/IYnYwljd6lzeOHbG5569YdvrorOaKwyjTnbqlPmE2ldQDSqFPkholHsNBi/Emxz1ocWrFl569lfLOM7Gpnj2Qv2/PHIBzb+ctc1R3afXOIRRRAMQMAIhYpgnPU0VD976Xhc+akZX50wpeZ+EHRW+17SGL3QpjCNiiHXb81/4C83/+LVX+xvNVxyoLAjSMVRLNRVEx75qMjl9Z9uvWDjT7dc0DSrvvvGB664vWluw0PFzmPq4qY2M8ZWwQqSUQqDISXnfSlS8aPAQkQjEoxYV6YpzCcBgolzG3aUIpVcJt/6xi93/NX6h7d+2tvOUKoSAgbmLilCSoawUP2eN47joa+dvOdP7pi/cEZr+i5C0FHte0pjdML427/922qfg8YYQDZjLfruZ//49B+fOrDAgA1KbBiwYbhL/jNV1FPCQuuDdg4J5br6Eq89/PZ1ud7cJTNXTHmJxugJ1bkk6uO0Y+PBi3oPnRxH3W0NOP4cwyW5YL/eZ+aeA79E8Nknx6BO2FaqE8tQrwecdYSBUmDpx1p/VDex9vWoa3zgzSNfeObvX7131+/2XUWISMCB8oNL1PzSMzcq1nNcRwlg5W3s+OPxJY1TkwsnTE3+BkC22veWxuiDViwaQ0au35r/7U9teH7rK0emGpz5q5hiCcxj3nr47fgl74PxPr/2ozcu3/O7vRs+/K9X/ffGOeND6qV+cu3amSua3z7yxv5ZUUknHbHAoixVglKRI8MC9RJWJ3wYcii8TNohrzJmXzbzhXEtDetV19fK21PffPTtf9j18r7zuvd2txqcyhCVSJkKhYtMY8I+nHMq9OXx7P/Zudq2Zz+yYMWEq6t9f2mMPmhi0RgyHvyrN3/+7quHpxrM9slENnepfCgiuSBEKgG5QPC5EAYcf/dI06Of/MUDl335ohVnrF7wRfmcpi1t3riJWNf4BBIiFY9wiE8wPFmoc4Xx68RIMCIRTLBRdCQYTzAty6e+nqiPb5S/R1d71/VvPdr22R0v7lnFbAZD8pOIPpVSBCOZv0JkA7+c78liw6/2rZq+qP4TqbT5cLXvMY3RBVrtE9AY3Xj18X3ff/2J9iXOzI0WDFj+MkYs17zFf3aWMbeds7Slz8HSaV/w9xvj/rKdPcl1X3/hc+v/7Q+/AIMw6+LksyY/O/2c5p3ONs7+Y9z5OZ9tt2y752D7x5DP1xDWBeUYbPF7Ets9hh18V7/O8k2AwbWyESM2Ji6a+Af52h7844EvbXzw9S/sfuHdVd7MmN723rmH92uLx+BNjvKfZ3L066zADElsnDjQi+d+uOMhAGa17zON0QXtY9EYNPJZa84/f+zl/8j15MSOTeFjUftWLN+3Utwnw/zOkAr+GAaWyxsH17cvymey75l63vTfen4XM2XuIYyduW/d9vMMTjkZnB8l7FPhfTDeEoIPxvGLeOsh1UHyqUD0swgmwcC/MnfVwrUzL5//fWrQbu/atr+8+6ttP9340cNvHnwP7w+RfSOBz4QV9aWo/C1hHwsJ6ggBGEOmK4dxzcmlE6alflLt+01j9ECbwjQGjd98Z8v3+473IeZHd3lmL5vzsfD1shnM9jtdOcQ4ZA4TIscQWrb9eP1Vdn/uR+d98eKv1IxLvgoAU1e0rE3Wxz6V78kmw/OxqN0ggORT4db7Ji9hQ0UkmOoAivBiz0Q1530L1xhxox0AwBDf/dzWv9vy8zdWd+/rWmSEzFx89JfKFMaEescsRoU2TDi+Y4qLKtu5PF756c7Vs5ZNWGrESBuAfLXvO42RDz2ORWNQyGftWV+c89guwizBUa8iE9HnUmxci3oci+i85/0tCC1nvHfemxf8zar/kZpcvxYANv3ri0+0/fDl1cJASXG4yaBJJdpRD45IpDI33gQgiI9LYtXDn5lGTeMAs+zxu59+56sbv/fSneHQ4WC7sE9FRTCUIwkikU15ZT9AgFIs/9PZWHr19AYA3dDQKAHtY9EYFN558eB/o6wg+QtkH4bsKxF9KGpfhuSLUezTUOzTa3vwxa1Lnr/1oR/1dnRdAwDTL533rOhTscPn4u9L9F8E5+76Ubiy5xsyeJ+Lt47z6cRc303ghxGvV3p6A2jMOMpslt72yGv//Nb3/utOQ/DJWArfiVwOt6GK9hRhX4pYL5b9MHDCsOPVQ7At1lzt+05jdECbwjQGDGaz2mf+ZfOnY66PJFAqUYqFT98yAMWiDDeG76MgvHLhQod7dx2a/OKf/+jHi//isp9YuUI8BkuwTkUGbSEsLmSlIqdxCdSLYkeKnQoj7gmB3ZPB2w+8mO18az+6dx5BKJQYTvRWsRHzXhsmmLwYRNXCm8goGLHdstoUFpjLAMYYug/0INtbWJ5Mm9uqff9pjHxoU5jGgJHPWnP+avZ/7qBKn0qYZPj0LQMhFSqYueTPCEgn5HdBMNre7+/ltC4QCCRsEiPuEkVJJTLMWNiheNBQduMIU1fYpyKbwmioXjSLucTCtZfLalOYR0jB/hmhuPizZ66dvWLyzXpEvkYpaMWiMWCcPNy3LEYsiVTEJQmRSxmKpeQYFoUDX+FnEdeB69dLZDXmycRbcoMiZZ/KYEjFW88TiZJAijrtPSJhCv8KEJABX45y1IvtvUnHPNXCt9/7+uFVs86d2ExiVBOLRlFoYtEYMA6+fewCI9IMJpKJSCL2EEglGJ0vkwrllIqfA0wik0gLVUQdiDyxl7dDp4LIOy25c5VqUZvISiaUjCAS3rTlEY+oWjzCUJnCKAA7gmCc9t0HTsK2WCPVvYZGCehbRGNAYDZL7/7DwfMch7FKsYhmr6h6gVwUpBKQCAv5VNTmL84MpspmjPJ8KvLIexA+CSVvHitBKiVUC5O2K23+CkhCJpLQ6HrBhAVFGQqy8QiJgsF2o8JsoU3/8Qysgt0QSxjVvg01Rjg0sWgMCFbebtr6zK5LY27kUTFzmCpXWCh3WEVJRTKFIdzvBwTCBFUSJhqvcZhIBBMYv3O/7K0fgilMSTbhjMQykQTEoFIwsvkrTB6RbQgFsywU+gotiVo9EF+jODSxaAwIVs5q6Dty0g9ZHbg5jCOX0NgWVfp8QB4oKftUaISjnv9cTKkIDvsQ0YgEIpKKyr8SdYCBkQrvaxGJBkVVi1gWzVkgtqROwI1ZsTlzWEA4Tv6wgKyyPbmW2qakCT1QUqMINLFoDAi2ZdfYmSyKK5bSiShLDYwMk0qgWgIC4kiGKwOyacyrE8VEiCN4MnHrQAjMhlrQZBw0EQetMQHLhpXJghUs5E/0AMweNKnw6iPkrFc68OWMxIFpK1x2fSmC+SuCYIoqmsAP0/nusS9NmNXwVWhi0SgCTSwaAwKzWNxx3JcygxVJ61LWqHs1qVCeTBRjWNSpW1i0qECgSnxfCoC61llbUgtn7K47a85bqQUzXoulUwdoTfwoMWNHmW0n7d7+mXYuX9e/59DSnrd2LOvfdbCl6w/vXBBy5giOeJRFKqJzXlwf9qm4RCERT3RZJpgoc5hXz7WDDVawAIYkCDLVvhc1Ri40sWgMCIwxQzaDGYLvRO24D5IkFokMkwZD8qSiGsMikkpx81e5SoXEKBouXPJq86ev+UFyQcuDqmtAYIDGzXYAiE+esDa94gzkDx+/KvXkqzf3/HFra2br3iUykzH+ZEqRSiTB8NFcagUTEA+vViTy4AkmpE68Y8hE5C4tq9q3oMYogCYWjQGBEFhiVuLiPhZhBH5EvrDoZblKJUwqsvmrnIiweHPjgcZrL35h0qeuuQnAgHpQc9L4Z5tvuubZ3qXz7jz4b499Lrv30CJAHmkPVIpUwuQRtJHVioo8BBXihxjL9TLZUFAykKuicbpCE4vGgEAAlBocGSaXCD9LBKkQgEvpEpF0MmK0vSr6K9rPQvw6c/KEA003XPFk40euvGUo16d26YLvzPjaZ3fs/8aDf9e/Y98S3hTmRXEN2BTmdvShcS2CCYyPBlOVVf4WOcRY5WvhosJgg+rsghplQBOLxoBAY7QvRhmCrMZlkIs0W2SUT0UOPw75WYqRSki1AFARjcq/AqDhkqWbhkoqHuJTJ66Z9MlrWo89+kyu751d5wmhw4QAbqhzaVKhrvKwSzrx1ZFhPMGIEWAyYUSrGdHfEosbAEFfte9DjZENTSwaAwIxaH9NiqLQm/cn4wr7VLj0LSWUipgeX+VnEaPB1ApFYQoDVBYohX+FoPaCJa9N+syH/qaS16l2xeJ7+zZtOS+7Zcd5YdXinQBTEIZn0oKvSMLOep5sqEskXqSXSAwiwXgqJ0wqUfXO58BMNn5e473QEWEaJaCJRWNAMEzaUzuhBr2ZTNFxK5SE52CJyhdGiJy6RZWuJcp5L0aCeZ/LIxXnO6Xfu/x3tD61cXBXJBrpqy54rLC/Y3LfH9++SM5qLBIMXCLxyrLZKxwBxhOG7IdRqxbedAaujehHkUkFknKJ18bboYlFowS0xVRjQKAxenzGpXNe5ed1F+YPkeZaF+dPkeYIUcxPEqyT5ocPHUvVzp1rJGLuEqqoqz//rNdqV5z1y+G4VvHZ036SXDhrhzf1sTeXPOXmS1GVvTYG8aZhZu68KGJ9uE1A8GIbBn5aZ+c6hM9Hbm9I5kyDMhg1pk5AqVESWrFoDAjEoMcnnT21bcd/2hdERoOpnPdKxYKQv0Vl/qIhn0pE6haFeoGkVMQ6gtR5rW8ZjePWDdf1is9r2WIQ5ub68hw7rkLxy87cKXx9oGD49CxqU1iQPFIsO234UfTFTV5wTV7hdQwMNsz6JGiMdlb7HtQY+dDEojFgjJ8/qS0yu/FA0uWXkx8slNVY7WeBRDQq85dMKgQM8TnTh3Xiqvjs6a/H6pOwe3pLpHKxQ/XBnCrOvkS/C3V9H7ZUVpEK77PhiCPkrGcRDn3HDFY7uQ7EoF3Vvv80Rj60KUxjwEg1p7epTVNW2IQVaf4S6yjXlipMWLKZyFlafl2wLyaYwvh11F/vjMEx4hSx6c1tw3mtjAnjNtatvvxBxzzF+5vEsqGoN3yzlWcu49vYvtlKLDOpnnGmNs5cJpjDmLiOM5l552EQG8mmWhBK9Jz3GiWhFYvGgJEYn9pieGNZpE5IPXtkOPlkqaST0fOvRKsXAJxDHyFHvVMOFE1s0gQY6fo9w3qxDOOoMaHhKCUMTnbiYqpFLnsRX56JzBbqRRUSVba59sx1wjN3v+5npVJxZpZ1tnHqahrrQAjRikWjJDSxaAwY1Iwdamydeqi7be9kz6lMIkileJp8CJ9VZCKOwA8PhARkovHqio1dcf4lr1j5KKlJHBju62Wk645Rd3Bi2L9SrMz7V6hU7/laIJFHmEiEjMVKM5mKVORtGCaumHsjCLRi0SgJTSwaAwahpLflA0t/t+Xt3dcXUyqhwZAR+cF85RJSMaow46gBkerU+CKpeDM/AgBDrGnCUcSMo8N9vWh97XEvtb9HBuWWA/+KLSkYPg8YEBABX/ZS4aMMUgnUDHinvVtHa2KI1SY2QYcaa5QB7WPRGBSmXLH4l6KfRPatWEp/iRAyy62jIZ9KEPJqgF9G+V6CsFylP8P3IQR+A1pfe0revknc7Jd9KgHxqkJ+wz4YVSYDv+z/2eG6qG1CZUUQhvfSQIHamU0glOiIMI2yoBWLxqBQO3Pis+HIsIiR9kXyg4X9LKoR9WyISsUZYR/4XNz9J8xTk5rEMHLU91m45+wPcnTbSOYv4isNSArGS8fi7csWzGTMVUZiNBjzzWTiZF5MMJl5qgWeXwWuWYwCdbMnAYToVPkaZUETi8agQGLGoYYFU45m3t3fRGFHmr+KZjKOzAcmT+YlOu9BRJ9KdEgx72dxOnaeYIg31H34r1WOup02kYiERJS9zp+4pEK4Nsy9FoGZjHH+Fia0k81kzD8PhnAG48D0FWzPAANoXHnG9YDOEaZRHrQpTGPQmPuFD/44ZiJkDlOFC4eW/Khzyazlmb1EcxHj2ivMOMpwZJXpJ6gH7FNzoWxmEOE8AFVAg1hGcfOV9FmVm41KJK5urzCl8dsQhsT4Whi1Nc9B+1c0yoRWLBqDxoRLzvphor7mNut4NjmguVdCZi8+uzHvqI9KMskrEFVIMW/yIn47XsEAAPqzyVNyoQqFOG8Kc86DcEqFSaqFcKoBYdXimrAIt71vGgPhVEtQD845L5rMVOawwKFPEwbqFrUAWq1oDACaWDQGDSOZ2FI7e9KhnhPHZ4ljWgZGKn6IsUQ0xcKMo8xfYVOYk0qFN0H5fpdsf80puVBWweQTYwI8wcD3tQSmMJFU+PbMTbvP+15801iJMjhSCsxknllNRTAMRjKOCZcvu/7U310aoxnaFKYxJEy9adXPzKQpjG73TWER5q8guaHNJU8UTVjBqPMi0U0KMxEpSmZiGflcHIzFh/sakUIh7pm2iGSaIkRtCuNNUf534AIdeIJW+bSiTF6kyDVTbR+rTcCoTa6BNoNpDACaWDSGhIaVix9KtjQdCkJ+1f4TgycMJanwaUZKkwrvUyADIp2gI2bPPX8bLGv8sF+k/v66wNwHV61BTTDS0tsmilREUkIEWaEkkRD/eEG9UWOiYeVZa6FJRWOA0MSiMSQYtck30+cu3BIoFG8cieiMD9UJYyckIhFClqNIgyekcJZknkjCo/qdbdB1AshmJw/7RertSas6b95nRDkTX0AkEEgiilTksG3KfVcqbROllKhERIQwmOkUas9ecG+17zGN0QdNLBpDRuP1l/8kOWPyUSHhozBIkTd1qQfkDYRUiBC9VJpUqIJUCGEgx48Bvb3DSyy2XYuTJ9NEUCoIqQui6PB5IuG3L0UqvBry1lGB1CBeE9cX5de7+04unLGNJMxXqn1/aYw+aGLRGDKSZ87597rlZ2xRZSI25BBhaaIqPp8YKYtUeKIoj1SCQZYcqQAg+RzQ3T11WC9OLjcVzz5zpzgeRyILiXDkcnDOvOoJE5Rg9gqZxuCrO35fsonMWxcbV4fa85c8AG0G0xgENLFoVAT1712xzkjEQj6V8FgTFiKVkK1f5UiOMPOESUU0IUWSCnHNYcc6pwzrhenqmku6TggDPwXikEKoVaqFJ5JAtcjKBkoiCZfFcTL+cTkVQwlDzaLZO2MTxz9c7ftKY3RCE4tGRVC7cum/p99/4auRAxdVA/hUebBUNv+QWUhFKqqONSASn1S4Dh0EwJEjw6tYDh+aj1y/77V3s95zpKJWIWHVwiCqFpmgAhWkJhVI5XA0mrdvoyaO5NkL14AQPQ2xxqCgx7FoVAQkbrbXX3PJ2r61L1xALUvhLOdt+apxKnLHKuYAE1PeA6QmCXr2Wa8hleqHaeZIPhdHoWDgjTcuQF8GzvgMP3dLeBSlt9PDHZORz0+FaQ5P+vzOo1PVXyD47KeWIQDiJsgll/2Y1ST6EY/nSL4QB2NALhe3X3rpZthelmR+rAvhBkyy4Dj+IEnCtSd+rjTmDqaEOzaGuAMzE2cv2hmbMe1H1b6nNEYvNLFoVAyJZWc+Vnf5Bav7n3vpvFBafP6NOmSWCgY/CmSiqINhgK5c+Sr58Id+Qc4662dIJHb7J2AVmvDuux/Cz392I3btmor2PfND7CSX1/3XR/EnH74fExqHh1h6TqZ9+5VPKNxnr3z2sicxofEYzj33d5g3fw2RiS6TaaVzZm/D2+8ssdev/zi4zQHGXaCAYJxR+BCIxMtG4E30BXeKZuaSCihF4tzFj5KYsam6d5PGaIYmFo2KgaaSbbUfet+a3HPrzovOYCyPsodUVyRNCwHobX/xQ3L99V8CpeGU90bsKBYu+iH+v7t/iK1bPovv/cudeHdbaySpEAJ0HwcO7F+CCY3rKn5BMplWnOxO+5EGvFLhy4uXrMUVV/4GrYvvj9xXKtVGVpzfhoWLVlACsPUbPg5uVwHBeBcMLnEgOI5PKkE9r2gAAnPuTBjNk9ackhtGY8xC+1g0Kor4kjPW1Cw/a4vobBdnkVQPZIQweFHlU6Gf/exDkaQiY+GiH+Leb/4ZPrj6SW7nCJUJgPa984flYhzYtwIvPndjcFwuzMs7j3PPW4NP3XRvUVLh0dCwnlx//TfJuec8qhZioq9F9rGQKH+Le+1rrrz4XhI3N5yKe0Vj7EITi0ZFQetrN9Z97lM/DE1apRqUBzn8VhxpzjvlSUvLbvLRj95dFql4qK19E5/9/BfwkRseVZKKVz52pGlYUrvs2dUKu4DIY5+97El88qavDVgt1dVvJCvOX6dyGQkEEyKc6DIlDLHZLTCmTH4cOsRYY4jQxKJRcZhLzvhJzeUXvsbn7FKFFPthrlL0V2iue4OCfOpTjwn+lHKRSOzEDZ/4G7z/6icjVctLz38cnUcvrfiFONHZFEkqS895Ejfe9Heoq984qH2fccZPyHnn/SQqJkGVtJMnG3Hkv1NOfPgDd8KMtVX8OmicdtDEolF5mOaB5F985rs0lehV5qGCHD4rDwSU3sCbJ7fj0su+N+jzqanZjk9+5mtYfNZrMAhgAM7S7eQzPUDbG1dV9BocO3o5ursalKSyeMlafPgj30fDuFcHvX/DOI7p0/bBIGGfVKRSkckmGKRpLJgL2jjhcQB6lkiNIUMTi8awwJgz66H4yhVtok+FH7cR9qnIub0IgdOoqal7UGqFR336Ndz8ue9h7rw3hU7eIABsYGtba0UvwNtvXoU//v5D/jF489eFl76A5qlDd5DPnb8RhuHvWxnVDCgUjeiDIXET8T/90PV63IpGpaCJRWPYUPNXd/w1nTjhaDBOhXcWq3wq/OBFt8KgQOvi7RU5odnzfoz3r34ac+a+GVIR+ayJk10rKvbld22fD9jiMQwKLDzjHSw975sVOca4cbthUDEgwJ17pmiaGP6zQWCcdSZIbUpnMdaoGDSxaAwbSOOEdfGPXPcsjVFfnfB5vohkJvNHw/Pmo3gcmDtnR8VO6rKr/hrLlr+JGA1MYZQAb264Ctverow5LNOzBIVc3LExcce4/P0PYsWF/1Gx75JMHoJBOWYWbIpFScUP325II/YnqxdCk4pGBaGJRWNYEfvkn91utJ6xRZ4hkoYcy1wHzL+BxygwbvzRip7U+6/9V1x0+ZO+mcoggJ0H/vjKRRXZ/653L8fbG1cLpLJ46ZM494K1SNW9WbHvYRi9Qiizf/3CBCMN9nfIPJWE8cEP/ACGsQ2aWDQqCE0sGsMLwzhufPbmH9M5s3aLAyK5t2evUyRS50gBxAwglSo/xLgc1Desx0WXr8WsuRuFDrk/k0QhP/TcYW2vXwBmBfs1CLDiohcxfeajFf0elPaF7IghgiGIDEuePq2bLFxwZ0XPSUMDmlg0TgHoihX30tYzd6ocyKJCQfjtGwzo76+t+EktWvKvuPzq54QIsXc3X4qOfUMLO85lZ+HkibRAKu//0P04Y8lPK/4dbDsJL8BBnJoygmQ41TJuHOif/Mkd0FFgGsMATSwapwT085+/h557zpueT4Ub/h3uAPmOEjZwsmvCsJzU8kt+gCtWP+ofHzbw5h+G5mc5dvhcbH9zlU9Wi85ai/MuehRmvL3i529ZtaGR/PIof/k6EwISM0AuuvB5NDQ8PizXVeO0hyYWjVODCRPWkRs+9hiJGeG36WDWrrBqAQN6T6aH5ZwSNdtx6dUPYc6C9TCIky9r5ztDS+9ycG+rEF58yapfYtww5CEDgEKhjouEgNLfwl9fr928+d04b/ldACprYtTQcKGJRePUYeXKb+LGTz4mzrGL6M7QUyzte2YN2zlNmroG7/vwL/yBk6xgwLYHT2RHD7Q4JjAAqz76Hcw984fDdu7ZvibBFFYszti7puPGAVdf/VXEYpuG7byqCzPiT+MUQmc3rgIYY0lmo8Yu2A2MMeemZzAIgeW1IQbppQbtIZSMnbdKQvrwpx/9Nt7ePB9vbFwiKBV+QAtfDwbs3TF9WM9r8Yr/jatvmItnf/ZZNE8/NKB8ZDKmzd4GA8CF1/wQ51/+XSD4TSuOruMtgHvdghTHEWUCUAq87/2PoLHpwWG9nsMLEwxpxlgDGEsym6WYzdLMZqZt2Q1W1mrsPnjyPi8UjoEgPbXu1ljc6KQx2gWgQGP0KCHoJoRkQNANHRFXcWhiOQWwbZYu5OzJx/f1rmx/s/OCQ1uOz9/1yv7LM0d7Uejph0EskEIeiQSBAQuUWaibEMe086a91jS/cU/jGZPa6qc2bE821W4z6xLbiUG7MZwd1nBi3LhXccvn78df/rfvwyqETWEywVAC5LJx2HYtKO0dlnMiJIcrr78TLXO3YOrsPwxpX4vO+Xd84r/3o2XuC4gPMVtAKRw+OAeEccQCRJIKACxc1ImFZ/wLRpcJzASQZDZrgs3SVjY/5/g7Bx7Lncwi35tDLpNHIWe7k5ZRMEIBv0zAQHFw85EHGKHufDQU8bo4atJx1NTHMXl+w9WxBN1JCenUJFM5EMZYtc9hzKLrcPaqFx7c8Vcv/nDbVYXeLAxiwYCFmHJpwyAWYrC4pQ3D/2z72095z+zdM65Zsq5p+Zx1dbMmPkfjsco7hocTjMXxs588gP/7758OOe2J5BegcAZJfvc/rsCEpheqfeojCr/5+Q+waf1nBSJhEaSSSAK333k9UrUj3WHvma5iYCxl5woLT7y158W+gyfQ39nrTkhGwUC5cjSp8G2gqAcIqGlg3JQUZp09boVh0q0A+qAJZkjQiqXCYDarffPFo3/z4F2b/qr7YK/Bk0Qw/3s4pbw8Pzzx54G3ufVO+6N/2D7r+PqtswxifdqAjbrp47vn3Hz5E5Ped87Dicnj1lb7GpQEITn8yfX34NknL8XBfbMilYpXBwbs3n6BJhYOhfxUGNRyrg9cQuGG1cvK5c8+dS9Stc9V+7RLwGQFq7V3y96N/R3H0X/oBKyc5RMJEZKhMa7sfXVv0jII9eFyMB0zCIFt2ejc14vO/X3rk2kTiy5outKsoc9X+2KMZmjFUkGsf/LwP//077Z8rrujN2n15x21EalQ+CWvTCxO2agUi7v01zlLM06RGJfsrWms7Wl679mvN119/s9TC1pGti2948Bq/M8770PnkZZQBBOvZAwCXHzVWtxy19XVPuURg87DV+GH337G+VBEqTACLDgD+PDHFoLSbdU+bRWYZbVm2w/f3Ldj/yXZjmPLmQ3YNoNtQ6FOaFHVAkHBhNWJXA+pDELROD31eMPkmk0TptT8iBCMLmvACIFWLBVAts9a9P0vvfPzjc8cas33ZiMUio3QrIn+PCRRSsaWFI27FNY5S+TzKBztr+072ll74N2915x46pULahdMu3PCVSvWNVy54n6aTGyp9nUKoXnqGvz5befjR9//FI4daVGmdHH6A2DPtllgLAlC+qp92iMCHfuc4AePVGSlwtzP4ycA1/7phaB0V7VPWYJpn+y9rn/n/g/nD3UuzB7sXGoXbJ8wnFQ0btCqoE5YpGohBO60y27ouKfgBM716tX7YWDo3N93XefB/uv6Tta1TJ6VesRMaPUyUGhiGSKOHsiu/tcvvv39d14+OjUGC4Y8uZWQG8t2p+n1loopekMkZPup5cOkEkFUto1ce8d4a9+B8b3rNiw5+cIfLqo/v3VT3YXLfmO2ND9W7Wsm4MLL/gZb3lqCtb9sKTpQ8uDeRTh66L2Y2PxktU+56mAsiSMHZvpOe49EeFIhBIjXAH/2mZthxl+p9in7p25ZrdaR46vzBw8vz27dfV2hp88lEtfUxX+VouUwMXhfO4pIGCEi//okFC4zRnBgR+8tDMDkGSkznqTPQ/tdyoY2hQ0Bxw7lVv3Dp978z91vnhgfg2i+Km3+Eh33cr3ssDeILTj5xWVgFqPeZ77sklVywYwDDX9y+Qup5WetM2dPf44k4rurfQ0BOGlQvvP1/8TG318QNolxBPPhTz+Iqz/2mWqfbtXR230eHviHDYK5S1YqMRP48I3fxYw5d1b7dAGkWW/mSqvzxPLCwcNLs23bV9kW40xSdAjlsFksMHmFzWIgRDKFeW3kMgmiyJIGznjP+CvjNfQlaHIpC8bf/u3fVvscRiX6eqwl/3TL249uf+3EJAM218GLSwqmrC+nPSU2DO+zsI5fMndb5q736hz1wi/ZseP1/a/+cUnvz5+81j5+YhmtTzXS2to8ScQPVPViGrETWNC6H3vebcWxI1OEPFsGAtWS7wfOv2INqHGy2r9/VbFn6/V4d/PVkZOsmCZwweXrcObZn0E1O0LGGllv5lpr7/4/73/hlW/l3952kXWocx4YC6RFMAHPAMrS9wZXByI5+TkzIXGzaHP7JEBEOaizLODE4dynGqfWrKEGqe6zMkqgiWWQ+I+/3/3zl395qJWCJ4Hw0lDWs4h6WyIOx+QVEE/Yt8L7X4qRirOfYH75wjvbZ/Wvefp9uXWvfNCcO8ugTY3txDCqN76htu5dTJycxKH2qejqnCwoFY9guo9NwbmXrEf9uNN3XvZCfiq2vP4nONR+fqizhUvAC89qx4VXfhqUVsfxzFgjy+VX2O0H/rz/18/878KO3ctZPuefKylKHlBnEBDquW2gJhgSsX8iXS8iTVBDhPpgvVVgSKVjO2tqY+8QAu3nKwGd0mUQeO3549944oF9F7kCnPOhiMtoP4jNOeyjfDFufRGnf2jJzcwYOh9hHfwJt+zde6d2ff5L/9T9yc+/bL299XNwuvDq4Myl38EVq5+GGVOndzEI8MeXVg8p5cpox8njrXjrlS9E5gVrnARceNVXYFQlZUsalr3A3rf/rtxDP30x//TzXyKFvJIjIPAAUwqR0OdQPYtsC2H+H/izlUI6FuRtpfPhI7h3vnXyG/291pXQKWJKQhPLAGEV2OTnHzn0IdcaGyIFMdqrnKVHMgqHP1cm4ElG4dwn6vMJSAWh/fGTb9k7d7X0fPrz38/c+sXN9q49H6/aBT7/su/gmo/8xJ/hkTeFUQAvPHojerqWVPs+qAqYXYtDe5dGksqKy+7Fx/5iPOrSD5/iM0uBsRZ28OAd+f94aGvhN2u/jHyBUw+OCUo5F4/KOR8SLiyirKjjSQMRJAUIZBMuA5D36W63d0vvTxlDY3VugNEDTSwDxFuvdt322nOdizzFQQZIJtGqwxbbCfu2BcURWkZGoYXPIfwWJ77BWW+8uaj/81+4L/uXf/1HduDg6lN+gWPmAbzv+m/i3IteCJnCvFT0e7cMbc6U0YrMyVa89It/UpLKsgu/jSXn/wSGceKUnhNjjayj44vWfzy013ri1/cgmwUQTR7FFYioGopFhhFVx8+TA6IVSTHVolYwwbI/YyHXby89xb/8qIMmlgHiteeOX17oLwxAkRTp9EPLQH3QcglJaqsmFQhkxM89TxUEha4T49krv1+W//L//I71j998hh06tOqUXuRU/UZ85HP3YNqsNmXW49//5gPInFxW7XvhlOP4odbQ/DWUAEsv/DbOes+jSNZWbtrjcnDixC3sqafWsV//5hvI9AKMCR00oFARAyGZImUUOUZgImMRZjF+u2jV4rXnj2EVbGQz1pxT/+OPLmhiGQCsApu8552emQQ8edhDJJMwGcimNYKwKqFS25AZTEEqPpEIRCNOky68Mb777hz7V7+6yv77f/hH9qtf3Yd8BabtLRcNjevwma98DdNmtvlKxVMtuzdfgP3bL6/2/XBKkek+D4f2nBEilbMv/DYWLH0OdQ3rT9m55PMrsWnTY+yZp+/B7t2tyOe4qCpw5i+oSURa5znNyyWV6P0UaVPGPlTkFSIjAPmc3Qjg9PXzlQEdFTYAHG7PfuBX39/359mevDBORF760Vx+tJcVigZTLkPhxkyIFKMRTn1vv/5nP/QYXBvXx+LX8f0TT0zBw+WXDx6YjFdeXk5Odrdi8mSC8RNOzZtxXcM7mDbbwoEdM5A5MdnvTA0AzLYxq3U7zJr91b4vTgkO7liN9b/+htD7nXXhtzF93iZMajk1iSUZa8Thw3fgD7//a7yx8b0k01cHf4Q8gVwGoW4UFuW96iBcGUXK4egxKNqj9LZlRoWFylwd4fabzdjvbZya+CEh5Hi1b4uRCj3yfgA4sKtvSba3IKkBhJSKZ9YKlAhK+2AiVA9RqSCFIgr2Izs1PbKQzAGc+YtXKqL9WXJo/uLxVXhtfStu/sxSrLzoP1B7Ckwvs878d7z/xvF44ScWDu1a5kusd15ehfnLNuHsy0/dm3q10HXkKhzbPxcUwWBIBmDi9J2YOvehU3IOmd7rsHvXdXjl5U8gnxc7bHhF4o/P9KqZ0My5sZi7MujIofCjBPsK+1fU9XyZQd2WcefmnEvQRsiMI9UxwvzvxxgDs9AIip2n5NqPQmhiGQA6D2SnF7KWghzEKcZV5OKZpKJIRUU8YXMYoHLeU06uh01s4AgkbGuWnZNRtmUC90se2N+Cb/zdl3DhRRfjls9/Gy0z1mC483edseJe9Pc0YP2vgUO7lvlya9fGpZjZugrjJo/8jM5DweGd56Jt3V+BkiDZ5IV/+kXMPHP4k4xahaU4cng1/vDqLTh40JlYjLM/OZ1uQCrE79jdMSHuzSMTDkg4b2Y5hAFwiQaEffIpWRBJJCCMO7eINm6WZBI6thtQwBhsxlKGfzANGdrHMgDks3acMbVSEVUGn6RXrUZkUoly2AeqQVYqCJOLRCq+6uD3EQrdlEOPo+3gPoNSAL9/eQVu+dQjeOyR+5DJtA77xV92+Vew+KL1MGhgw9v26iq889vrq31fDCs6269HX/cEx67pXvv3XPvXaDnjsWEm9DT6Mqvx+vpv4VeP3YOOgy1Rzg7iKxAEPha/7FWJHXW0Q54UaUOUfpLI9oIlrJzxK9x+FG0FYtQoCk0sA0A8QXIGLaI8SgyWVG4nq44iDvuwUhGjusSQYkimMd5/Eg4zLqZUiOBwcZdeJ/fg92/G7Tc9he1bPzvsP8D5H/x7XHT9jwVn/vH9U9HTOXbDj4/uXoItL/2Vf73Pef/XMKN1DWLm8KUWYawZhw7egUd+/ATeeP0KQY5HxgcHdTxJyCokIJhgO554VIQRHf0V3V5JWqE6FlF2noUoAqQUIIRkqnNDjA5oYhkA6sabx00zbI4qRS6lfCvqtqLakZVHVFSXEFrMlXlSkTlCeBD9Oil01CMXqnjaOo+04B+/9lU89p8/glVoGrYfIBZvx/IP3I9z3v+Y/wa/54/XINPVUu17Y1jA7FoQdzIvSoDWS+9FS+uziCeHawoEE5bVijc2PIg1P7sHhYJ0Y0WRCu/khoJUikSJcQQDt32UUlGZxUqFI6sUuExGobKiTtiOElAKTSxFoH0sA0DDBPOQaRJYZZCGaJKKICGVL0Tah6c8gmiu6PEngpoRTF28Uol+6wPkB57xbBWsVKVbOXakBY88+Gns2jYXn7z1nzB56pph+RFSDetx2af/GjXJPhzcOheN0w6hsWVszixJaC9qarux8MJvg8bymHfBQ0ikhi9P2smuT+DZJx5EdxcEf47sBFE7OVx/S6BaPN8L4G0SJHpk4c39w8hO+yhSkf00KpXDFPso5sBX1vH18BSLzhdWDJpYBoBJLTVtyVqKbHdp0ihpDitKKhC3CTneeaXCq5iwWSvcDoCggIrbnou/sXJl6uwXr/3uImR7a3DV6vOw4pKvDcsPYSZ24uJPfhLMTgMkP+zBA9XEjKXfgWP0s4bxKGls33w/3vrjanR3BfO5eOwg9+okopdHoFp4hz5CBAOfYJzOmlM+XL3XsDwnvxhFVooo5LlbPLLx6yFGgvHrJrYk7yKUdAzj7zHqoYllABjfHF/XsrB2Z9fBnjkkQpkU87WoSIU3bcmkIqoMBbkIpARp3wG5IEQq8rPL25NZ8NCqyEOVToS3rVECvPPGeejtrsPhAy247Jr7UZd+bVh+EEKrl4351GL4SCXbtwpv/OFubG9biYIV/NZ8GJc8kRgQWfZUi0wqUQQDhDv4UkqFBTcz/EABZRuRYOS6YqokdGyuXcyk3YA2hRWDJpYBgFLS3TwreeBtgjmihaiYKUsiEpWDvQxSCTISh8OOg33zfBC08/p9mVTU9mTiH7cspeK1kWd+PLB7ER7/0SIc2T8F7139KGYtGP7QWI2BIIVjh/8Cb/z+NuzfPcex8SjkAeCSS2lSEeUClKQScFRps5h4Ki5xySHFEu/JRFHKFBYqc8cmCCsZahDEa6o0HcEognbeDxCLL258NVFDIghBshwB4nphHSuDVIqFHav6eLVPBRGkAgQPHG8Kg7dNOUrFJx5JvXjlV59bhR9966+xef2Xq/3babhg9hzs3/kPePGX38KB3XNCv7X3+wk3V4mXC66dRxj8VMNymScAZ3M5WkydFVl27cinAel+DrYjQluoyhH75ddPmVd3p1ljnL7zAZUJTSwDxOKLJ/zgzAsbt5MS5i9x8KTsH5GXYVLhB1WK5q9AJZEIFRStXtRKRfVAld2ZUHAEg4B0+PKRfYvwxI9uxB+e/adhjRrTKA2rsBQ7Nv8DfrvmDmT7ixAJpJcGlHFPSDcYUCbBBO1VJBG0D3f4srAStpW2k0lHKEv7VUVLggDxpNFBCLRiKQFtChsg4jXG9vOubl739n8dmF/Kt6KK2pLHrYgDHaWycqS8rEqiCKT4KHsQ9QMVEIb7FzMAgwJ2AaFOR04sRiPKhACH9rbip99txZH903HVDfcgMWwhsxpqpJDPLcdbv/sm3n1ruf87yrYe3gakMnPFYgA1ABoDDAMg1NnWtp0/BqBQALHhj16P8rUIJiz3pmScaiHCDSo6+Z1q/mYOUsXIJrEoR71XhvTVQ6Ywd2nGKcwaY2u1f8jRAE0sg0DjtJrZ4ybVoPdIb9gkJSkMGlIm/Ms+T0wQyyFiiBrUKL/JFQ8pVpEKCAGpSYDUxEFMEzBjDplMnw7U1ACmAXR3ASc6AasA2BbA3D8rD9h5jowglmWz2UuPfxyvP/1xvPcjwMUfngFC9Nvf8CONvp6rse5nP0VPN5SkoiIRagBGDKhLtyOW6MP4xnY0TtyKmmQnapIdSCQ6QI0MGDNRyKeRzTbDsk10nZiDI0cW4MCBS1Gw3GwrhOvEJWc+TxoISKBU2HFkqLFHUJzJjSn3TdREwhMQVzf9zIbrjRjZVu0fczRAE8sgsGhl03XL3t/c9fLD78JLoR8ePR88E2pHvSpsOEqpMIm4VCY1njhYEVKRSI5SkMkTQS54D8iKFcCK81cgFttQ5Oun0Ze5FG1vPIED7cCOLcC2zUB/j0sq4JaSavEuSjYDvPCfQOe+vfjwF5oA0g0gX+3fdYwihc79d+HVJ+5GLuc66KEei+L3qgQwE0BjM9A8DZiz6GMwzVeKHyYJ1LvFyZOB+QsaSSZzKfvDHx4jR46AMQZAES3GKxQAINGqpVjYsU9CCKsTvm2QADNYL5f5kGNv/0agVnQ0WBkgzg+uMVDs3Xziof972+8/0b2/GwaxEIOFGLFguMsYLKeeL/tLW/xMLDc9vlfnpNp3UulbXOp8y0+vH6Tkd9Ptc6n2vQnD+FT6/tTGXAQbJQzGLX/eSW+44VrEYlvhjAfJo3Qnb7p/MTCWAmMpHO/8MF557lvYshHY2eY8kIZLKt4oeW+aYa8+Hgda5gOf+NpliMXXVfs3HXNgrBnvbngQ219bhXze6Tk9UmFcb+qVGyYCU2YCC8++Ema8DU7akgLKuydUMAEk0de30n7qqaeQL4AR4qoT6papP6jSK6vWM0LLrC/W1nnrCR9DLot1AMHMc5quNGuMlwZ5HU47aGIZLBgaX3xw+941/7AxxROHQC5cOXJJbJ9gnDoVqVjCnC0+mcCC4ROIRy48gdgQEle6ROOIBwbz299cQ85ZdicorUT67xQYa4RlNSOfbUFH+2o8++hNeGeDmlS8fF8xCjRNBf70K1/F+Clfr/bPOmZgF5bijWcfwsEdrbAskVTAlZP1wJKLvouJ09bANHeBkK5hUJApZLMX2E+seY65csDr8Pmy14mzEOm4mfI4ImHuHC8ywTB3Phh1W/V6EKleqkuOT2DKovFTCIEeFFkmNLEMAYWcfelP7vr9i21P7S5TqYRJJSAaSbFEkoolKhZucjB/wrFSpBKjiK2+BsaddwynjyOFXPYC9HYtxZbXb8bG/2rFvm3RBNM4Fbj2S9/GxJn3ADhdBj4OD2yrFVt/9wB2bVzpKxLB/EWBM1c+juZZa1FT2wYjthNk2EeSp9iG13rZ3r3OfCZlkIq8Puj8iykRuW20qgnWB9vLddSkmHHupIWUkl3QaqVsaGIZIroP933p/3z6hW917jgWEAexEEOBIxFbSTwDIxUrNOMkFUxinlJRzTbJ4Eyh7A6yHNeA+M9+chnip8r8xBqRObkKHbtX4/Vnb8C29QDLhwlm0kzgT//2Y6ipe6Tav+sohonuw1/EK//5LYFUHEcBcMZFD2PijKdQU7sBlJ5KR7SJQqHV/s2TG5lrEsMASAWc+hDIQWkWK0UwahOc146vm3nu5AuNON0ATSoDgh7HMkSkJyX/7UP/67y1tePjUmixGClGQ+NOeMd6MJBRrouK9AoPAmOcg949OSGixh2ARgnI1GacOlIBANKJVPphzFnyMVz3xRX40y+txcIVQKpOjBw7thc4eeSCav+mox5WvkGIzKtJAYtWrsGFH7kdM868C6n6h08xqQBAHrHYNtLcvDZwyotOe//+9+9bb/4V7yYGd99Hpd8P6sTxK0S5Htwu5GjJ6WdPvFaTyuCgo8KGjszsFZOvvujPW3Ov/Psm0+q11GHACB6agDhUgxoVgxsRTSpQ1Ckjwry2pgkydSrgOFZP/QNjmBuwcMXVmH9uK955+QFsfmEleo4AsIB0I1DfuGHIxzi9kUd64lrMXbESub40zGQ3Js97CummHwGks8rnlkHczMhTGDO/oyd+2SMVOa2LE/7rtQFHBnw4M8QQZhKEDYvrA9ISIsIoQXNr08fiqdhaaFIZFDSxVAgX37o43tNxkr39xFbYvQUoR9irlIdyAGOR8SqqcTGSUpG3EeopBalJVPtyAdRoQ+slF+LMi5txaMfdyGUaMe2Mf4FRKqxVoySM+CuYd8GVYKz5FPhOBgITlDodtUQkwoBJgVTEsGMxSSVRhBrL4cpOmYXWB0QCiVQmndF0c6I+vgZDIxWTK5925HQ6EkuaMaTg/vCMIelUe74mUiAkCK8kQB7O3Asl49ev/uoFxM7m2LbfbANyCuUClVLhTV3OOajMW952/Hpv1jtxG4RMYby6gW0BJ09W+zcIQEgHmufdXu3TGJMYWaQCAEm0t98gSujySKV48spwnTzI0tudOLqeGyAJh1SaFjXdWpNOrEHp592MKMcYQwoMqUyvtSNVZ8wgBF1wwraBMMmMSdI5rYilUGBL33krd/dLT/dc13OiAFawcWBXP6y84xgntoXaWmDSlBhq6yjicYaps2qw5JIJ326annzIiJE2lLgRPvD3lzawbL7r3ae2CIpFtt+qc39JyyI+GNEfw+1XQWbCwLFCHmzXLgBIlvouGhoVhIlcbhkY40xTIsHIpBIegR9MICaoFsgDIUWFEqznt+fKzkfE6+OoaUisAUExk6EJIGnbrPlER//WXL+NQp4hl7XBXHuaN6rf/QJ7/e9GCWJxgkSCIpEkGDfBaCIEY3Jw8JiOCmMMja/+LvfYi8/2Xbr5j1kc7cjBylmw8xao7ZAJChYo+GgtG3HDQozaiBELZowhEbMRN22Mn2iiZUEtpi+syy//0IyvpCfVfFt1XNuyW5+66+nNu5/dxoUWB1FfQx0YKQ+I9CLDwmHGYsixn4G5LoXYD39wFyZN+jfokcQapwYp/OEPvayjA/xYFkCK1lKUVWNZ+O3UocjiNuL2BHJ48YSFk26vGZ9cQxyVJ3f0abtgz8ln7Tn5rNV8bF/mPgYCxgDPjsD8N0fxzU/ObwbiEIxzSgSTp8SuN+PoiMXIzrE0TmZMEsuJ4+yWB/4t88DvX87h+NEC+nsK6O91wnsN2P4yBj6s11KGB8vLmgRDKkVQl6ZoaDIx/YwGnHv9nIebF47/Fo3RTd45WFnr0hfufubFnU+9o9iPOPLegC2QjDhepRipBKHFwSh7McyYwvZH2fsj7g0Kct65oH//900gVXfoaox9mMhlV+Lpp19klu2TCh9WLBMFBkAq6vXqAZaq8OJ4OonGMybPJZT4A4UZYy1W3p5TyFrT7QJLHWvvecCyGKdKAgIJlJekWEImBijIxyGYKVONaw0D3TGTHKQU+zDKX/jGFLFs22Y/8P37+2/Z+W4Be3fl0d9rOYMGOTLxO2u3jicXcQR8QAKRAx1JATUJYMKUGjRMTKCxpRZnXj173ayV0z9JKGnv7+pnr9/3CrY+8npwLGm8SohcpEGQAdEEAyL5dC5UGHnPKRZhcCSXVdkztcVjoJ/9bDuuu34x9IBEjeGEZS3Ff72wET29XOdOlARTXGkMhlSKj1kx65NomN0IszZOwNBo5a2FhazVYhfs9LHdXQ9YFiTy4wlEJAumUCxhooGgXpxFsI0RA6ZMNS6LxdBOKdoxSs1kY8LHkslg9Q//T+6Jp57MY9s7eZdMmJ8L0fdbAEH4rruEv54JvzsfoQVFhJeX6NHKWTi2pxvdey0cfN3C/vXtl05b0rR3SmsTpq+Yjgnzm/zjifecOowY8vEVPhVI68VtCOSIMcD/8u7GDMjngf/8zxbMmvUQzjn3eozSG1hjhMOyWrF71y3o7eFuYAg3vehXKT7jJB9qrF4Pf598yLEQ1ozAz8IKNvpP9KH/RB/Lnswhl8nD9sjEOx9um3AQAHe+EI8p+Db98+TKijrbAvbvs140DIKp0+gyw0A7Ke7zGZEY7YolvbnNvv+++/OfePI3DqF4CsVP0AhRoVDYfhJIQbmUYQZT5QCLVjMWpi5ugmkSHN20t7QZLNL8VSrxJG/+ilYt4emTnTJaWoDP/cVanLf85hEYRaQxmlEoLEf73k/gzTfuEN/yJQXAKxDOTxJVLk/VFFcqfDv5PCLPUzJ7yQpFNIkBfMQOk98CISoVcRmsmzqVXmiaaHf9L6Pm5W/UEks+j+U/+L/W+u//ex7Hj1kuqXA5szyC4c1KSh+LKhEk7/cYeA4wJRl5+w+Z1jyikVK5RJnClKRiwyCyf8UWzF8qUiHeW+O4BuCWWzfh0stvhKGnXdUYMtLIZpdj184bsW3LTfLru5DbS+ik5bqhkYo6F5mKyKLqyiGVsElMaf6K9LeIS291QD5ORUsLWTiafC+j0RRm9mdxyT/9b+u5f/t+3o2KCsxWgclLNoGF/wTFGjKDifOjRJqi3LbwtlGZs7xtvHOMuNcg1cmmrAjfn5ACA4QJK4PtvXN02/gPOoCT3cC//PNS7Hh3M27+7ArEzE0YRW9HGiMIjDXjZPcqvPzSgygURBuvHDnlm5jkOuKbvIqZv0qZwuS5Xpi0TfE6lFXnnBNcExiE8wTEry60B0Lr/aWiT9i3j22dNo0sNgzswiggl9GWK8zM5rDya18vPHf/v1uhTtkVnb4PxKvziYJIS34dwsQBngh8PwznZxFGwHukEtQpFHFozIlf5kbgc1+GWw/pplO/3chjW8RjyozEbcRs4MkngLv/x3qcOH4TgHS1f2yNUYUUbHsB9uz6Ml564UFYhfANGbr5iXDvyqQjv3nxk36J+cO4Z4HzrwgvV4JCCJ6hcJ38rBL3eHwdd5pEPC6R2gTfV7FOaif7VLlNAQLsP8A2WxZmA0hV+8cuhVFFLLaN2f/4LevF//efdqBOOIIQ3vbB37+iuS9QLbzDXh71XkIhQPzRwwolPLOjap8k4uYLzp+78ZWkolIt/MPq1AWk4jUhUD74724F/vLzD+AXj2wFY83V/s01RgXS6DrxCTz35Fa0vXGHUyX3nPIDAunhCROM3Gn7DYRyMOo+klTc9eLLHoH8XAftPeIi4WeII5DQ8+d/p/BjRcqo86HYp/f5YAfbbNuYDnG0/4jDqCKWh35ib/jxQxZs260QOsrwiw64ZiLRiNuoyMVfRtwAxaK1gm3UN68sdVVvKvxzSYj0tibsRz4xCDsN1gf1oYdUOAEAvb3Amsea8Td3HsTB/fdU+3fXGMHI51di+zvfxe9fegB513qqemERHkwiPVwQt3ObhtoIz5NU9reBv42gOPxqAjWpSGQiHZ5/Vv19hsiECI+iSpXwlgih/1JcKu5rBucBoOMQ28oYRvRL36jxsWx8gz32ve9b6d4MVPcaAEXfCqB0qHE0uajIJLRNaHv+mVCbxOT24bcchax26+GqLBCA1qZADeLPHkkJQO0CSKZXQVDew8YUF1BxZ/f3AXt3Ad/+X3djybK78We3rEAspjMPazhgrBEnOm/EgX2XYM/O60JvTogue74Kxw9CQBIJMDMOkkgAlIIkkwClwVNKKJhtg2VzsPMWWC4PVrDg78zdvZjUUhFezN33Xp2zJOJp+ucmt+MO6e6fJxEmba/skPxLEbGOWyUTj/eZMaBgoTkWQ4ZgZIYijwpiyeex8l/ut67b2x74TfiCZ3Lyq/h+k9+R9GLjfGRKcgmRlUQckSQBhN50hJe1iH0Ue8uJTUij9sxZSLRMQmJG87b4jKkbaX2qg9QkOoUXIALnruvva2T92QYcOzYbR460sPb2OeTwYaDjALB/P3wHfxSp8OWjh4DfPQ8c2r8e133iR5h7xq3Qjv3TG9n+VTi0fzW2br4NBSv65pV7YkqB2jqgthZk7rwbkUh0EEq7QWkGhORBSJ+7sfOZB2MmABOMpcAQY4ylWL7QnNtz4Cmru9chHPewAsEgCPUNkQT3oIbXBV+DXyd/rRCZgIS2F5dEuU7JyRAvLU8uR46w9c2TyUJCR2ausVERbvyv/2ax+75v4URXcKGFfFiQQm+VocYR4cZSaLGQ06vYeJUSY1iCOluaMdIOjsOVnXMIQo7NGgPpZfNQf86CztplC9ckZk55nCYTGzDwsSYpWPZ09PctRldXK9u3byXZvWsp9u5pxrFO4OgR4Ohh54b1ZnL0JoiSZ3hsmghcuqodl7z/TiRrH6/2faFxisFYM052rca+XavQ7qoUJpEK48qpWudvztw7EU8chWl2IhbrgGF0wkklNNToJhOMpZllt7BcvsXq6VvQt2P/t6LHxHDhylxdaEm4cGXAJ6CocGMA4mfVm2TYTs6tg1BH+HbwLBUIkY1hAJMmkilkBOYYG/HEUihg6err8xs3viGH8rJgLAefN0sYIGlxpCINQORTukiDIvkEkZUlFX5AZHSOsIYls9B45bntjddccCtNJtYOy4W17Tno7b0AHQcvxdYtV2Dn9jk4egg4dhQ4ccxRNZSo56hffA7w8b+4HQ0T7q/2/aFxytCIowdvwx9fcX1uEqkwAsQTwOx59yOZ6nD/tiEWawelpyQ1CbPsBXZv3/Led/Y8ZHs5vQRSoaG6YMkPplQvZaIR1nn1pMgYFr8NIBMNEdbBV1jhNsFuAGDSRLLYMLDtVFzfgWDEE8uPH7K7/umfrfSxY6JjXczk6ykUeYCkxY3AtwSCCSeg5MhFlYl4wKQSVj38yHtRvTh18ZoYxi+fh7l3f+p6o7bm1CuC/v5V2LHtJvzh5Ruwfw/Q1wv0dgOZk6KaMQDMmA186ZtkqIfUGBUwYduz8dKvtzoOepdIYqZDJtNn349kbQfq6rehJrm5yoNsTSuTXVXo6lna137kHn5ApUcq/Lz3AoEo1Ig6RxhEcgkpk7BS4Sc0C9bxy6BcrmIhBIgZQFMTacAIy/c30n0sqcd/FSaVUKge4P4O3NgVeRwLxG08lOUb8ZYKeyeJ3C4c+85HiYkx+YBRE0fj5Usw7//7sziq9fZRU7MWrUvWonXJxwCY6Dn5Ubyx4Q689vJyHDkIFLIAbMCMAan6qpyiRlWQB6UdWPKeu3D00HIwBtSkOjFuQhtS9Ztgmpswcgbt5Y1UYg0AkAOdgC1a54DAByMGEaj9LKE6eM8ugTwHDCBZBoEQGajWyX2LSqFEKRabAbaNJkpHFrGMZMVi9maw+rL35R/bt5+FOmlfsXAqhXrpTnjzF+H8LW6dn8pFngtFpTgE01i5/hbVdkVyhBEbE86eibO+d3sTRmrCOdtegM2vb0WmB1h01p1oaHxkEP4eDY1TBbPQnfloz7Z9DxVTKCFzl+uXUfpXFKYxACF/i0qpyL4VpXKJVCjRigUAmhrJYsPAiErFNJIVi/n4r+zH+voUqlFSLE6l+CIgvCF4dQiUDF+nivAq2zyqUiqh7eQ3EG/gldMgNXMiFnztE3eNWFIBAEp3YcnyWveTP3WzhsYIRd6oq9lAE3HYuQLXwUN48AP1whOG24yrExWLqEy855qPEFNFdRULPy4VYhylWAgBGIMJZzT+SFGNI3qAZKztbRv9WcWgRUCwZ8ljWWSzpfAH7r5yG6lNXAQyqYTacAcl3A2o2i5MKsH+Ui0TkZg07t+qfcFLIA/nxs1Ak4rGKAChdFdq1uSPOR94E7XzACrdHREduDzYOOAJIrQVXmpV9nfJ1CW/HPP7KfaZX57oYhsZQ7La15vHiCUWxmC+s4Uhmy2hWPg6iWwEZwogsgpRbO+2ke4XNblwbzz+voV1fBsAijIIkJjYgOYPLF+HEfS2oaExRpCniVgHMdyZmSLGkPjLEupAdL4H64iisyBuW548wmPhiHDsECnJxwbUL6wORlT+sBFLLADQcQh++pYoxSIrzKKKBc5N4C1VNsxocxa3LPHGE+yTk0gKgiEAklPGo+Gcuf9S7WutoTEWQQzjIDFj0QE2nqXBf6aDt84QuXDPtspMFVIqKL4UyEY6lrw/pWLh6lxz2IjBSPaxoKdXbQYLXXggxOCyj0VYyX2MivRSk0rEDQdINy5HVFGqxW1nNtQilqpZV+1rraExFkEo6aMxCjsPBA+k/PaJoAxwI+od4hFT+MNvJH/2F0V8KcWWRFUXeukV2/ovySMMI5ZYGENjPh+hGAClYvEqvAstvhEQ/x6KekOI9q0E2YFl8gkO5G0rqx2FauEOaiTjwEh22mtojGqQDKhjCgsIw11DiucDE1O3BM+2TC6+aihTqUA6B7mPUPUvUaTCEeOI6stH1MnwsCw0RY4lilAsAXuzASiW8BuBKkJD9SP7clqQKwjfJMIG3MmCwLH/amhoDCuk51ecRpg3f6kViqhinOZBOLK3eVipBDnL5I4Dyv6llI9FKHMv0SMNI7ZXIwQZqjRHeQ2ChWxz9FWGu04VESZHZgUkwdcRoS48iClqEGQQQcKTim8m49SLm6V1RNlHNTTGDlgKzMvozRFJkX6FiB2JopMPzF6SahBfHuU2ivW8WIly1PObhUgl+CqFal9pHiOWWAwD7fE4Z7eUljI5yLZNovplFL8gH6ERJhXFfcA77lU3S4RqEdcT/+a1sgUnBbmGhkbFwRhLMlsaYB3R2aueadkaQUIdAiDOwxKhSKSl/9LL10PsNvzPSmuJaDIjZGQNARixxAIADQ2lFYtQpyiLYcci8YTfUhD1owmNwhEmKvUiNgpNC+wuCz19sPpyy6t9rTU0xiRslmKWDfGhD5u/xHVS584948FnSEpFXFdqqSK1EKFErFf3TyMLI5ZYCEF+2lSCWKy4YhEGMPHrOTJRmcSCA3lvJRB+NO+z8mYTflGiuMHCZjDB58K9smSPdKF3Z8cN1b7eGhpjEXbeaoZtC8+o8iVVfimMCClWKZVoZRJxQImwIk1givOU30259SNqHNyIJRYAWDCfoCbhlKP9HBKby+olZBILfr2QapElr+rmUo1hkd5oQoQkkJN49+Q6e3Doqdc/Ue1rraEx5sBYI8sXHDNzhFKQDAtOFf+yKr1oqpRKWJGEzWEq5SKfR/hYJPQyHTpX+PvTprAyUbjgfIJkkhRXLF5rIvzW4oWX1IooM9XSN/x2QUJ1MoHw7YiwXjwW/0Vsy0Z32x7kOk/eVu0LrqFRBry8VCMedja/tK/9yEMq85evSkJ1zrakWIcfqVR4y0cxElG3izSLqYgNQbm+HnMBeLNvjgiM2HBjAPmrLqeL7/2WtbnzGJTMDXfpBglC+v0l26PEQlydKHEDAhEjvfhNidBOrENoP6LJTP4iQH/Hcez41s/vW/R3n15HDDqispQCABhrQaZ3JXpPLkBfbzNMsw9NzU8hnni+2qemccqQRrZ/JXLZZjDbhGF2w4x3IBY7CEo6ATKixmIxy261+nJzmB8R5tR7YcP8OBVxXZhkvD6GSc83/3IaTpcfbf4S2/HHKP+z1A2NuKSwI5pYDANtCxcQ7D/AUCiE5WC0YgkYRfhxeO+K8AMFv3rIAS+EJnJmMI6Q+OR0SoLxlkpdS2BbFk5s3IG93//15pZbrrmQxmOvVPXKM9aCfH4O+jIL0HW8FdvbrkbbxgU4chDI9gIxCiy74Iv4yK3xqp6nxqmCCcYa8NqLT4WmIq5LA3MW3oqa5E4YsQ5Q2g1CulC9iadSzLJnF7p7V/bv73zAIwSfGISXwsC6oJrHnkiE4fUJLPRshy0g/iUqWi++wEaSiEyAXBt3SEZXla51JEYysQAAbrnJWNPWxlYf6GBKG6N8sZ1/LJC4kGSp/0ckUpF/QCLcTKL/RFUXQTDgDq64qb0dMNtGx69eBctmX2659YMfM+qST+HUPZxp2HYzCoUp6MssQNsbN2HT6yuxayvQnxGnJqbuk3eiU4+9OX2QB0EG88/6Ona8fTdsFvTEPSeBN197wLmfDSA9Dpg7/3okaraC0k4Qkodjphnut2oTDGlWKCzs3bL3ZZXq8JchEhHNYQK5EBJKue89ymKafBI+jnIZRSbq+pAZTDqH+nrMwAgzgwEY0RN9eTA//dlC7uXf22AsuKAUzJ3si4H6E32x0ERfyqmJiSXWEXGaYH8yLn7eer/OLj79MD/FsTS/vXwcca77oJya3ogZX7z+kdrW2V8lBu1A8GAO+VrCeftMAkiBMRPZ/lbs27caL/3XLdjaBhzvdMiDckTCk0oi7kxL/Ok7rkVNak21bw6NUwnWiGNHb8Lxo4vRsf8mpwoQemu+HE8A9Q1AXR0wddpiUNrhEk0Bwf08lPvae7lJMstq6d95YLPdn+OmE6bukgRLvwxhHYg82RdChONtozJxhyb0UizD41x4xRM2vUFJKmLKqHQ9msgITAk1GogFP/2ZffCf/9Vq7uwM/CiEIDznvVDmyMWfSVKc9z4gCb6zL04Q4RkgwwQjziDp7durtwWiUROM85ec3oTx712GCR+67GqaTDyPoT6E+cJS9tqG9dizB2TPbmDvbueNk8AhDk9be6RiSAQTM4CLrujEBz+2ApTurPZ9oVElZPtX4a0NTyGbRSSpqMqEAKkUUFfvkM2kSQtBaQcGp8zTzLJa8geObLZ6+sAKVmg2yNDskCRqxsiAKMJtgdLkAogKKWoJiMpGyh3IrQ599svE3106jSkuqYwo/wowSoiFMTTffmfh4DPP25J90YbhKxYWmpqYJ5dAwbikAJFMQtMFc6QiTkMctA+TjkcawVTEYtkW9lmMVChsGJTBrDEQS8QQq00gOW8akovntZlTJm41xqd3EUryRuP4DaSmZjOzrCb09S1g3d0LQWge2WyadRxabLe1XUI6j5o4dgykuwvEKvh/sC2ROGSlwpenTAU++fl7MaXlu9BTEp/uSIHZzeg6sQptm+5zqkqRilsmBKAUjBpOeXrLV0BpHmasGzHTIZi4eRSEcClKSB6MJVmh0ACbmaxgpQEgv//QA4y5oklWJoIaoSGFEq1UxHNVkUtYoahIRrV0/oWVC1+v+AyRcAgAQoF0PRpQPV9WUYwKYgGA3XvYt77wpcKXtmxlSsVCCRPUCQUL5roPEYwlKhgFqUQRRVidcOYyweSlLovHUZGKFSgsjjgNYsMwKWI1MRimARojzneOx0BNA9S2QKw8iFUABQNhFkghD5LPghYKILYFQpjj7ANACIP/oRSpXPun23DxlXcgUfMKRuiNrFENsEbk8ovx1usvIpvlHRPueplgIHXgUqfuZiFmhqFUGMxmCJFDEYVSKaUSTSLFSAb+enUCymJmMG49xMvptXVNYN0YgWoFGEXEAiD9iyfsjX/7d9acvn7m9odhUpEJxi+HCEbs7AUi4f0skp8kZP5S+F7U++LOwV/PH19FKq7q8r4TsUWV5pn+SOBvIooygUsohPmk4pubeVKRTWGz5wB/+on7MXPOd0HptmrfABojEiZsezYyvcvx5h8filQtJKgTfR0l6ooRSLH2EW2KEw9CbZzTL+1jGagZLGrWSeGz/4/fHUG6fuSawDyM+KgwDt3XfoBeu7edbX7wP2z09wfKJfgBwuNZfJ+MEA4C8L+YMFpWOaBRVXbaBQ8EuO2DGzZ0I/KSnN8XgXCji/tgUppvCPtkxHlZZC55iMcC+K8efonkr4t7jJoa4Ir3tePSK7+KdMOPqv3Da4xo5EHpNtTVd+C8Cy5Dd9d52L7lWyGlEnqbR5F7kl/KzxGJrnOXwZiT6Dbec6+acyX4DCUZyPUDWarNYJLIA/doCusI0vWYMZKViofRRCwwDLR94S+MubaNHQ//1Eam1xv8JM406XzgyEX4zNV6ERZSZ01CHbiizBGC/HYkxwiqCcOpZ+52qjZMah/Uh89ZJkBGGLw4fO8h4SKwpQeX28HsucDqDz+C1rNuB0ZetInGiEU34vF1mNDYjrOWduCdtofgTAkh3nglSIIh/Jw423HLkp14CRLz98M/z2EyUZGLR0gAFONZ5KX40qvkWqmjIlKB70pcUunECMsLpsKoIhYAoBQ7//sXjAbG0PWzxxhOdnvKxXmzFwmES9ngwlMnQW1YAQSbc2Nd+HIZpMOKkoRcBoqRCgupFriExJ8/3O9P/NnwxIeQuQPFWPDA8ndxOg2ctSSPj378ZtTVP1zt31ljlILSnairb8eSZR04fmwldu+6p1xSKWtdMaUimLTE4/EDJIspFZV5KkqhqHKChawBRZULVy/VyYqlvp6MePMXj1FHLC66//KLBjFjYL/+DcOhDriv5AFZ+CYhcPJT+Sty5VAn75Wd7VnkesWDo9we0Q9JUVIRVQ5PhB7BMK7sfV1h2lXuLSvgWpdk6tPAn31qLZavuLraP6zGmEAeicTzaJroBHrs2X2P//xxnWc4DUpQjl5XLuEotvf3w7cFCHWfJXgE5LUNiEg8pzLUkGIZaQYT2op5yNJpMgNAfjSRCjCyk1CWxBduM8h9/xK/f8ECinjCuw+I8kYNuKUYKbjKh7uBvVBG2fzFuDJ/k4IQEIPASMSQaEgi0VATHId/o1KoHVaEVMQyfy7FyAnKNp7pjRECJFPAF++8X5OKRsURi23ApMmPIO6lKI8wCw9IvcDfl7+MVAvcXCsRpjVCKczaOGLJuEMwNFqJiCnuSYll8NHP8sHvD1x9+B0UhADptKNSCEEHRhGpAKOcWABg3lxy508eqln8sRtMpFKBfA2kqqwgvL8IxSK8VSgm6JL9LBA7ekYIxs8aj2WfWoZr/8/1uOjuq2DEYyJZcR270MmXIJWgDQ07J5Xb0vC2/DZGDPjK/3cv5s67s9q/o8YYBaW7sOTsxXBDiVUEUszRXtIJH7nOPT5PDCHCAWjcQKIhidpJdahrrkeiPgFqUqiitoI+gXtHjVyK41BEQuG6H4mPvPOsryfeiPoR709RYTSFGxcFY2jp7GTX/dv92e88/WQWzFaNvC8Sekzs0HiTcBixGDrMj3uZNKsWM5Y2YdkNi75S25hcS2N0Z19npuuNH7+OPc+8w4Ua20XK7hgcRdkLOw7Ci+0gnQ2f2sYvu+HGgF8mBG4YMpx1d9zxOM5eejv0gEeN4UUK+fxSbNr0MuM6fqZ6iZKXZawrGkoskBNCbQklMJJxJMcnQU2DwE97hCRjrLHnSN/WQt6OUCbhF9EQGbl1RNg2aMMrFmoQ1NeTBgQpb0aVSuExZojFQ6GApYcP26vX/DJ7z6u/zWLPznyQO0wgF5FgipOKPHLeQsxgmLN0HBZePHnnnOUTH06Nr9kQSxg7qUHaAIDZbM76+36/Y88L22H3ZcMpXfgBkjyJFCWYgDz8FDY+wTBhXA/xCcYlEW4MCzUoyIL5oHfdtRiGMfLS9GuMRaTR1tbF+vsBAKrBizxJRI1dKWudZDJWj7KH8DmWNFE7qa4WokIw3b8YY6yh93hur5WzYXtdZilzGAAiqZ1AobjWFQrUp+kUQpDBGCAU/3uPNWLxYNuYc/yYvXrPbuuK3/82u3rvrhwO7s2jsyMfDESUklLGpMGK3oj7RJxh4tQ4mqbE0TQtgbnnjF/XOC31WnpSzSvxVOwV1wbqg9lszoYfvL5lx9PbTDvTH1Ym/HGE+ghS4VVKJMF4gyJ51QKfYPxR94SBJOKI/d3X70RT0/0YAzexxqiAiXx+Kdu8eT1scVxWOQMbixGGkjiUxAMFEcHftn5qehmN0W1Qm598kgGDyZxkrqnersIOxhhsy0st4+7PX7iKxbWTUUpADSBVS5uIM4/KmCETHmOWWHgwhpaek/Ylhw9al+7ekV/ZsS+3oKfLMgtZCwQMJ47kQGwbZowh3UCRSABmjKG+wcg3TDA6mmcmN02YkthUN97clEgZGwgh7ZHHstmc1//fWxvf+eU7abuvX6FSZNOXFR5pL+cM80iEcNkFlKYwXrXIpMKZwiZPQuzefxixeYY0xizSOHr0Zra3/TuCX7IMUihrneSTUR1Drg+ICS651C+mBt2F8nwbAtl4lSxY5+2W35eXA23MkQmP0RpuPCAQgvb6NH24Pk0fnrswmFmVMTQCQF/GvpTZzKSU5BNJuolSHMUgUtUzm83Z9OiWl996fGuaZQswIqK9VM5HhnCbwJZMAWILkWhBdBkFYAdBCQAYoe4AySC82A89jsVAp00FNKmMdZhgrBGEZDByfutuUJpHRIevMo0N2FEvOMWjnPm8gnGfC/fzyYM9m9NT6hcSg+xC6ec/IAfJOX+647Qglii4URdI1dLHh7wzhsa3ntjx7Pr/aGsmtuWTikAeA4gIExyUgqPTIxIKRmxh/EqQ1sU9JW63zvEZiBkDpk5th/NGVe03JhNWoRWFXAtsK414zS4Y5maMnI5wdIKxZuT7luPQzifQNPNGJFKbQI0OjIRMCoTkB0YckF6aENT5y6jtFW3AT+Qlt3MK3R09W9NT6uYSStpR/WdkVOK0JpaKgaFx92uHHnzp39+aYzAISiX84FCAMLVqUYUZEwoGm7M7q0bdiw9giGDAEYzNgGPHW6p8xZy06z0nVuH3v7gPR3Y5ge+NU4HL/vxKmInnq3x+oxu5zEpseekxMACd+x4CiQHzzrsVqfTzIPQoqkfcJhgzVcShIgy/8y8Wbiw8QyiDTLx6sZ1INkB3R++O9JS6KbL/VKM8aGIZOsyuw5lb1tyzYTUYlOasKHXCXAXCQkkmPRKRSYUfvc8rFVe9EJFEeILxTWGWBfvwERjVUSyOTbrn+Cew7pEHcLQ9yKQMAhzvALK9CzWxVAJcz2lbwLb1D4AYwLxzb0Vtw1ouxPxU3QMmGGtk+w/cJ55eOYQRoWK8paA4yjV/8b4V559MLnbenmOYNI8ROEPjSIcmliEi21tY/ehf/f4bVp6VUCphsgnqHRXDBNXikIVvc4boa2Eh/0pQDhEMcXKE+eRy5AiQz7fCNDfh1HUsaRw7dBt+98tv4NgBAFbwoHsnXdcExFN6ZsqhwkxuRk090NfjVng3gg1sf/0BGCZQPwGYecZi0FMXbs727z/ozC8e8ZyE/Izc6QvLKOIR24bJAwrSCZML4DwzPZ19L9dNTK4wYrQPo3SgYrWgiWUIsPL28rXfbXus63B/yKcikoSaSES/C5VMWRypEJlUvLLsX3HIyHtBYzKpeG9k2RwK//dH62Ofu6UWw00smZ4b8O6bt+Dt9Vcg2wvk+pzv7ikV5skpA7jkxtsRr3mp2r/rqAeluzD//GXY8spG5PohOigYUMgDJ44Cib23IF7Tibp0GxKpDSgS7Thk2PZsHD8OJwpVJgW3TUiFEOEZKG3+ilIsagUjKxQhPBguuRztX5+elNT+lgFCE8vgYe54rfMbO9YfkUxTat9JKbOY7LQPjTAmCEWFhVUL4Cgd5jjqCQMkUiEEgG3DfqsN9vMvvEivuPxKVNbmbqI/swod+1bjrT/cgOOH08h0A3aOm1BM6kHqJwCXf+p21E14CPrNsBLIg8basOjCxeg+uhq73vxGqNdmNnBw9x0AAQwTmDbnq4gnOlGT3AkzsROU7kOlfotCYSl6e5fC5jLFCr6UcsxfBGHiQcXNXzK5gAAnj/bvSE9MNmmTWPk4LcaxDAe6j2bvePh//PE73QdOFpnD3pvSOHr8ijxjZHjEPQuNZwmndVGMwPdnjlTPIkkJA6lJwLjg/A561ZVfx4QJ9w/yUpjI5Vbi5InzcLD9Uhxsb0VH+xycPAZk+xTTHUufz1ixDWdf9lUk6x6p9m86JsFYC/pOXoKtrz0ETy0ACHvM3bIRA+JJYPrsW2GanTDj7aBGJyj1fDLlkk0KljUb+XwL+vpa2N69D5QabR/yJSKirTTokUnkokobE/U5OAY4cpHXA3WNNYupE4KsX3zKgCaWQYDZbM6T39u+Y9NT+xR5xsLTDavLYbKhoXIUqdhC+hZDTuUiDZjkSYXPFeYTzNQpoBdf9AqZM+cljBu3GYnEPlDaBcPoBCGdsO3psK0GFKxG5LLNKOQbkM02ItPbjKOHF+Ddty/F8aPAyRMKIoGaVOJx4Pz3r8X8c74KI7ah2r/pGEcK2b4rcKzjChzcdYdgcw0N/pDsUmYCSNQ4f5OmXA8j1gVCCqAkA0IzIMQbPQ4wlgRjKTDbRL7QiF27nmD5vNKnIo6Wh0AqpYkHkW1l8mAhsuBJpBS5iMv6ppoZZBRmGq4GNLEMAvu2nnzg53/fdkvvkb6IEfVRSiWaSHjF46sUSbmUVi3iZxKR2oUQMRml5yclpgEyZSrIuAYgmQTqaoHaFNDdBfT1Af0ZoLcHyPYD/b2AbRdXI16ZSJ/T44CLPvgDzFh4J/Qb4KlDPncpThy5Au3b7wbgKpYipFKMdAiAmOkoHCPm3Av5vLOM6uAVnX1ZKsZrG0k88OtLKRY12UDRHqElNSjqJsR1xooyoH0sA0f69786cEvXkZzjsI+wDasHQrr+D6V/hfrhwf4oe2F7BE58YYAkF2pMvNBj18cCxpW9fQfOfOfQBN7Mm7BsYN8+sP373CE37kPH+0YEsgCCDkcysXhfhh9QAwKkG4H33fBVNE35erV/yNMOZnwdGpuPImZ2YffWbwEsQrWo6qTOFgQoWM4fckHnLKmA8LMBbj/FfCrgRFUJf0uReuI/O/DXO89C2Kfi+VxCx3Y/2zYDY2ggRBNLKWhiGSBOHM7ecnhPn/CWVWw8iuNcZ9zDEQyQlCPH1KPuqXuD26EBkiEHPiBYOXinvUwqTlI8puxX/IcLCL5L0Q7H/ewTiWKdYQKTpuRxzSc+hmTt0DMdaAwO1GjDuImdmBfvxo62B2C5CgNA0d+YRKwn6nZMSSbuv6gAF3e1aKpSE04UEalJRkUiUfVqkgnucWaCkJGQtWJEY9RP9HWqseGpw1890t4ffeO7ocPF0rc4JBR+sFioTEWS8ffr1VOOoMRjhkmKgn/gxQi08CRMTCCUqA6lTMIBBWYvAj70mRWaVEYACOlA/biHseica4PxItKbhfsiolwPbr28jXAfIWSOCmcp5netUC5FQ4pV9fw+ScR6dwI/QLEfCO2E706A3q78DjCkq/0TjnRoYhkg2rf2pi2LKdVGNNmIHXdABNQnIfhlypXFcS6MIwiE6gm3P8oREVWQircPKpnppDBonzwA4WGOMn/J6zyp9ME/+xHe95G5MGLDMBiPNVb7njgFGI6OLIOa5PNY8p4VMBMikQAIvyi4yygi4sos1JkryECpOlRtVPtR1cv7LPaZ25wvKEkGwrbMsR6mhuH3GFPQprABIJe1r+g9aUWqDVGdeL6OsH8lvK2YuqWYKSwYFOlsozKF8b4W71kJzGKijwUI8wfPC6RYA+GzYuOmScD1n74ZdWk+hUhl0HXoy9j629tACDD73EfRNOuuat8fw4J8/yp0dVwJy0qiYdIrqKn/BSoX8JBBLLYJi8+bgZ7uK7D97Qed6iKkwtepXjwkwhAd6RBergbWhj90MZIJfyYo7VNhIXLhv5d0KbQ5rCQ0sQwAB3dkbuzrscKKBFy5qIKhrhsi7MAPm8Ko+6B5hMMTjEdE/Ah8j8ikkfcIgn+cB9UjFYdgnH27kYGu3yXcbwyCVN67ah3OXv51xCue98vE0b334M3nvoi+rhQogHz2JjTNugdjMVqn69CV2P/OlwAAR3bfhjnn3YxUw+MV/K55ENKOuvQanHXuZdjy1ovIe1OGRL15SHURZi+lcijHCV/Cd8KU9cU+I3SesrnLf2a4ryh+3WDbvh5rRyodi1f6px5L0KawAWDfjr6V2X5bVCe8SnF9H2HzlTzS3jV3ce15ExkksxTvk+H9K8ExqHRMz/wll0VTGO/LCezpsqlN6kgiTSXu34Qm4M8++22cu/LWYSAV4PjBL2PDb76M3q6Uz5qWZSKYQGlswbW9gBGgUADe3fAg+k6uBjeRVEVASCfM+Cs4c+lizF14q9/bhlSJVEdU94ekPhQvUd7uQmawoj6V8hRK+HOUT4WElo7oIu7XDJbCNg4qe/3HGDSxDAAnjuSnWwVA/TBEKZigU5eJCD5BUDdXGOU6c94UVoxUokgtnEomTCoiwcj+FuX3AyLKBFjY2omP3XwzWmbdBUq3VfwHOHnsNrz6y3uQ6w9eLakJzF3xCMbqeJiGSetgxOFfb9sGtm94CNnMqmE4Wh6G0YZ0w1qcsfhaxExAJhX+t5dIhUmdeTnhxmpnfnjQo3cKxZRM+YqlOLmE2yj2pa09RaGJZQDo7S6kLAvSA1NEpQidelgJqCPBOKIQ9q0mFX+/7jrIZMGTkpJUwkEBgdmOI71ipNIwHrji/evwJx+5EumGHw3Lxc9mVuO3P/8O+vvFMTJNM7ehed53q31vDBviqXWYtujrgW2TAJYFHN5zHfK5SzEcb86EtCOZWotFiy/EnHm3ig57XrUAUSqEDwCJ9o9w2xRZpyaZKHOZV5TJhq8H1MSB8O2t8rFolIQmlgEgn3fmyWKKjjsUBaZ07FOwCIIJwpQD5eJ1/AF50Qg1QkPHgWwKk0xrPKmAO1axBJmhhzVRAzRPAT72ya/ggosvQyy2aRguu4lCfiVe/NlDyPQ6najXwVITmLnk8VOZ+r0K6EZ90zrEEhB6uKP7b8Lbr7wIq9CK4THL5GGaryDdsAbzF12Plll3qt/qI1RIUf+IZCqLVChR5FHc7FXal6JSXNxSRSaeWWx4fuMxB00sA0C8hoIYnD9CIhWhcwcNdc4IEQzva6Ei2YQ6enHMCk9EYqixyvdDOLUj+1dkX1CE2Y63q1MDqKsHrnr/Wtx6+xRMmnzvMF1yZ+riFx59GV3H0oJSAQFmLH4FTS2DTZ45emAmXsKM1jsD1eJeB8sG2l7dCGa3YLhs/oR0oLb2cYwb9xxmz7kZlHr1CAhC9TxAQRgKghiyQill9uLrA3IhoXYcZUjrCLdb7sPY9OlVCJpYBoDGKYn2WFx++y9GIuHOXiSYsCksWrWoSEXlX+HHsvBjYuQxK7Jq4U1hkllMVjHTZwBfuPNaLD//2oqHEfOw7dl4+Tcbcexw4FPxSIWawNR5azGcc4iMHOSRSm+CWeN+5Ei+UAC2btwBxpqH9QwMow0NDY9iwaIrYRiIIpXoMSzRznwU2abYPkorlmhyAYjPEf4SEBz2AQGJZjPCk5CGEppYBoAps2o2mTVGpPkr0kQW6tx5dSL5MkKqRxH9xY/AF0bhq53x4vgYkbCYcO6KAZP8d6mtA/78s9/FZ2+ZgmRyLYYzjp+xFuzZ+hUc2COSivfG3jQNmND8cLXviVOGWPwVzGq9NewEIM5MkSePrx52cgEySCReReviGaitBSA/AxDqopNBFlMoIhkMNrS43CiwsGlPurwIb19Ta0yBHsNSFJpYBoDpc5NralJGpPlL6VsJKRXeWU5LqJYgHJiFyjREFkK4MiTlolQtYfXEQqHHznbk0ss2kf/+36/FrNlfd1XKcD5YKRzefwvWv3ATnGgJzgQGZzn/3K+D0NNBrXjII1G7zYkQAwSCYQB2vH0fMj1XYHhG6fPIgJAOzJ3bgDPOWAbT9E9Fna7e/TcIVaMOZQZKKxa+HqXJhVuE9iGt46o1sRSBJpYBoG5c7PFU2izq4OZNWWryCZuWZELw9yX4TaSySzLh8SxiHjJ1RgCVT4UPKqC+n4e0ntlp3H7bV8kVl9+IZHINCBn+WfSOH70FLz15N3I5KEkl3QSMa1qH0+3hNs3NmN16u6Dc/NGvNvDuWw+hv294IsVE5AF0IxZrIwsWzCALFqxAzIwkACEMWalqwvVq0oCCRKJJg/jtAbUaQeS2/gpOAXn7I2SMhrZXEDoWewAgBJ3zzq7r6Nidabay0RmK/Xp3pD24PlHOKB9YeWwIfhICN2WL19F7qfLdej5dvlDmR+F7UxOLafQJcVJYeJ/hlwngjsI3Fi3oNi58z0O0peVRJOLrTtlF7uu9Dr97+m5kep30/IzrSLy8NGet/DbMxGk4ORjpRLKuLWQK824iywa2vfUEzlh2IUzzlVNwQs6ofdPsJPPmzSBWocXes/dlVrDU/pIS0V/KkOWiJFJKkcjrpaVS5UBYR6T9J+uMKQD6TsG1HdXQxDJAXPTBCbdvfb37sYM7e4vmDFMphpATXNrGT+NCbH8d/JxglCMfN5WLn6qfLzOBZEjo5ZbASZYvpnbxSMWYPg3mRe95xFg0/wdIDMPI+WIoFJZj/Uv34OjhRp9UvIfaK8eTwPiJ6zAW07eUg1isHclaoC+DEMEAQCEPdHVeggmTjg7LIFU1MqAkA2p20Dmz56JQaLHa978Iy+amZQj7UNS+FbWvxblv+fXg2sv1vNKQ51VR2LWkfRGhjm/uq5XTSykPAppYBohkrfH4ssvGtx3d399q51hJslARTjhdCwLVIvhA4JMK/Em9IBGJXHYVjEKpBArGkfb+Z0pBJ45H/Jwlr5grzrmXpJJrTvmFZawZb772DezY0uqzYdArBOXF5z+MRM1YHrdSHIR2YM7ia9G24Qm3AoIkJgD27vwGjFgfxjd2AqfAdBkgD0p3Ih5vN2bNXMgK+RZrf8dz3qySTEkeKt8KpHb8Zwhko64XlzyX+PPlymTCR3pFBATU1BlN0GqlLGhiGQSWXz7ujh1vnHxu+8Zu8BNl8SZvwDN3McffgrCrwCnbAfHIJMMTiW/u8pJT8qTizSCpVi2MOz+PUBhhIDEDpDYJc+Gc9uSq995JalPVmislhX177sJbr18RqBROcvHl5pbnQOjOKp3nSEAG8cRWEOrkEVO9WoMAu3d8B/GaDtTWrcGpT3eTh0G3ESOxKzZz+mKWy7dYHUeegm2X6VspZgYrplgQSS4+yURugyL7AZJ1sRmEoA9arZQF7bwfBOI19PlVn2z+ev0EE6ClHPM00hTGp3vx0qbI0Vmh8GIoPofSv4THswjztMRiQCKB2MK5SH/xMx9LXf+BGVUllUzvKrzw1JeQzwPg2Fcux+JATer0VSseCOlGqg6RpAI4pLP9nZ8il1uO6iVMzMMw2kiy5vnYzGlzSSIBUBoiidIhxRDaDy36SyITYR2US+I47LswVvPRDQMIY2zoezk9YR7el737wb/dcXe2Jw+D2KDEhgE7VFavY0I9JTYMwsKf/W28stPG+0wJAyXM3cYpE+IGG/vtvHrASMZRe+6ZqFt18WUkbm6A8wZWvbcwy2rFIz/ejJ5u56GngaNXKBMCzJoHrLxyLuhprVgAII19u7pwaD9EJ4CCYIwYcNayuaC0HdV923bT8bDGwqHOg3Z/1j9nOcQ4bBZTmdGgaA8gqp2/iCIcvg7wUrgAQLI+1gBotTIQaGIZGlJH9mW//ODfvnt3LpPnCEEiEb/jd+t4wuHIwvBJhfnreILx64uQCiW2o5G8zy6pJKY1Yfy1l343PmPKj4hB20FIN6r9oDDWjN/+1xN4563lAYHAJRQFwXzgo3difNODOF0d9wFMWNYCbPr9Zuej3IlKDupEEjhjcdMpCRUv59wdJGHbzbmDR7cyy0aYRKLII0wMkZN0RUZ/cQSidPgHtrFkfawW1X75GoXQPpahITNxeuLeW++d3/nU/93/nV1vnAjMX4T3bXB+FN+BL/pTAN5pbysd+KJPhbrbiZN8BTNHMhgNKYy/5OxXapfM+5FRl9xEzNhWjJxOOY2DB27D228tByB2AkzqJD3/Sl3DhhF0/tVEHpR2wDABqwClKYzvMLNZoK/vUqRSz6H61y/vLynti0+b1ADGUsxmjblDxzbD9iad875DKTOXoyxKzwBZmlR4/0tNXayJ86loUhkgtGKpEHJZ+4o9b/fc9sJD+67rPtwXaRrzVEdYwTDuMxNMZpSElQv124kmr2RzAxrOnrOpdv7UdfGJ4141apMbQMnIMx319a3Gow8/gUyvpEwUSoVSoLYe+PCfzThNcoOVgzS2v92Fk92BE18whSF4wwcAwwDOPGuFm4F6JHaUKTAkAZZijCVzR7u3soLlf69iiiXSHFbMH6NSKASoqTOnuCHF2vQ1BGhiqTBOHM5+acsfjt+6+82uBYd3dAO2JfhKeFNYyNci+FR4gmECMfH+lng6geTEeqQXTNlUN2fyK4lJDRti9amXyEgkEw+W1YrfrXsQbbwJTOFT8cxilAIz5wAXXzllWJNe5rJXwLYaUJNaB2CwZqMU8rnlIMgjFvd8WMOBFA6096LjAEcsgJJUvI6zJgksWDQafFQmgCQYSzGGFBhL5o73bLYtr68qwxxWzLkvKxQCJOvMJhDkoQmlItDEMkzo7y1ct+uNrtve3dB5Re+xfuR6csj35sDyBYWT3uZ8JbwyCZRMzCSI1xgwa2JIpONITazrrJs+fmv97Ikv1UxMrzOS8ZcwGqJWGGvErp334Mlf3+YEwpEwkRCJYGIGsOQcYMm5DRgeU04K/X1XYGfbLehoX42V778WNannB3E9nTT/r6/bCEKBs84f7H7KP9abf9wIm4mkIqsX3qw4f8H1qK0dCSaxgcBTMyZjSAGI5br6tjJ32mYGuOZSSFNpi0uPSAglSNTFZgAkT4C8JpTKQxPL8MPMdOc/2nWof+WRXSdX7tt8bGkhkwdhFgizwQoWYFkwaGDmMuMEhgEYlCFmUtQ0xDMT5jVtqp1Ut61mfGprzYTUSzQeOxUpOyqPE8dvweOPPeCnbCEKIpEJJ2YAF18OzJxTi8p30iby+eV45emXke1zjjd1FnDmuYNRR2nsfbcLe7e738MAzrv0MpjxVzAcnRZjzXjjtYOwbIlIIkjFK59x5mWID9M5nRqY7l8MDCbATObVMz84IC+MT/FIxLkE2ncyzNDO++FHPpU2H06lzYenzK/HkvdNBWNoZoylmcUa8v2FBYWs1UQI8t5zkKiLt9EYPQiCwog2aQ0UltWKjRtvQa9LKrKzOVT2PlNgasuFGI6OwLZb8Nb6l9HvkgojgJmA+xY7UBT8eeIZceanf2fji1i8fOGwpFchpDtMJCVIBQB27XwR8xeMBpNYFAJScL8X74/XqD40sVQBhKCDENIBSmCY8Q2or/YZnRKY2PLOV7B58/LA/h9BKkzqIAGA0i5UnlhMnDyxCocPBKRCAMyYey1ABpO6I4/J05Zh55aN/rmf7AZ6ui9Fetw+VF5t5Z2sDrbienLXVfa9ZHNAX99S1NZWe2yLxhiFXF2JsgAAHopJREFUHnmvcWpw/PhNbP2GT/A51BwUUypex0gAMqiOvjj6+1bhtZfvE3LtgADxmjYMjgTyMIx2mO789N4+215/ANm+S4blusZiiCSQ8BDyoN2ePY8hn18+LOekcdpDE4vG8IOxZvv1P97CMpnQLJYlScUrU3q0oudk2wvQsX8VslnuOBSoHw9Q0jX4HZM+jG+Clx8OIIDNgOOdK2FZrRW/ttRAJIH4ZUAO1WW2DWSzLWCsseLnpHHaQxOLxrCD7d5zF9v+7nInKpafGplIBFNExTBW2XxXnUeuw5a3bvOPwxzCQ+MkDNIM5iGP2Qsv9KaJ9kfB7tx+N052XQogNSwXWZXORUEqfn46ELC9e3+KbG7psJyPxmkNTSwawwkTufxK6w/rP8EsK0QqXufLVJFhAISR94w1VOysentuwJ4dV8JyMhcEKakJMHfRYgzN75CHGduK5uk/EL8DA7Zuvg+Z3lUVvcK2519xj0WKk4qcHZhl+1tg23Mqek4apz00sWgMHxhLF556+mXWeazZnw4ZRMrM7JrGUML3YlnNqESW3kJhOd7d+gl0HLxCPA4BkinAMLZhyA5t0on6hp2+avG/gw0cOXwJChXzbZiwLGEEevCd4JOIkH078Fk51/zAwQdZX99SAOkKnZOGhiYWjWGDyU72rLLa9wf50Xz/Cq9UKDflQITvhTFg966XMVRiYawZO7ffhr27Vwf7do9jGMCEiZX79ulxG2B4p8spr/1778CRw6vBWMuQj8FYOpiTRVItoZT0PKmI6oW173sMltUy5OuroeFCE4vG8MCyZ+effv4hcU6ZsClMmFXTX6cgmMOHASA5hDNK48jhm7Dl7ZucjyQ818uCMy+s2PePx9vQMvNepb9o9467ceL4amBIjnPTUXFSRBhHHIwnE/86q0xiBPauPZvBmFYtGhWBJhaN4UDKPn78auvwUW6SMc78IpnCvM+yQ98nGAbgwAHAtgfrZ0mhL3MpXv3dN5yPis5++owfwTQ3oVLjOgjpgJnoikyzsuXt+9CfXY7Bm6BM7N27EYwJpBJFHEKghDD3ibvOsuGqluEJLtA4raCJRaPiYPlCa/aZF78jThPgzYopm8KINHum5NB3fS+svx84efISDLwjNtHXdwWefio8Rzw/TiY9bicqPYCxtnYXDG6ciXz8Ta8/hWx2OQbTmTOWRneXv081cQTrVLM2yhNsWbvbN2rVolEJaGLRqDRS9tHOVXbXSWFqZPjTKcuqhZuCWeF7EQjmuWcfRKEwkAgmEz091+H5Z6JJBXBSuNTVVz7lSqJmK+Jx9TG95ZubnkN//yUYGLmkkcms9ElXQRzyNNj8OqZsCzDGtGrRqAg0sWhUFCyXX9r/4qv3MHdyLjWRUMn0RYuQCvUnPUN/Fuytt+5GoVA6qoqxZhzq+BJeevGnKHiTYUV08PEEkExurvjFiMV2omXmV5TH9JaWDbS99RROnvxwmQ79FPr7V7IdOx4TFAfvjJfViEw0IXMYfId/Ye+B9Vq1aAwVOleYRkVhHT12hXXiJAihYYsTuCEjADd2hV9H/G2I3+lx5Xe2XAfbNsmsWWvR0PAKYrFt8E1YrBEFqwVdJy7FkSNLsXXrTbAtcSS6imBmzvo2DGPXMFyObsTjnUpS4c1VBQt45+2HMG/+7Ugm25FIbAWlHeBTuTPWCMuag2y2he3Y+ZiTKj860kv2u0SayLzPXpnZYJbdTGJGJ3QeMY1BQhOLRsXA8vmVuXfeXR10cAAICxOJW/RyTTJunUcwSlLxytu3r2Y7d60m48eDLJh/LwzD6QDz+RR27vwSuk64k18h3NGqCCaZPIrhmssmkegANQAmzuseVi8A3n33PhAAtbVAPA5MmXo9KM2DMcC2U2z37kB9FfGflFoXIiBf6TjbWfs7NsZmTB3eSdU0xjQ0sWhUDIWDR1Znt+9ZTiJUR6hP99+k5XVFVIu7DbFtsGOdYL8/9mVvnbMNEfZLVHmzeJkUM4FkavimO46ZHYjHnXnngy/FnY8iVDjTB/T1A13dj/FjUgQV4n/XQa4LkUpwTszSqkVjaNA+Fo3KwLIX5Hbtv4QxIjjt5bLnX1GFIaMcX4sUZSb7YQQfghzSLAwehNOupgaoSQyHGcyBYXQ6DnyIJjlF/q6oEfKhdop1Id9KsXXy6HsF0RU6jugIMY1BQxOLRkWQP9R5Q3ZH+0o/dYsUlSSOWeEJggqDJwOCUDnwwwQTjn4iwr7ETpZIx3Ad90Zs+Ew+lHZgxsybBcc6fz0U56jq+KPNVwqnfLF1yvEuENeBgBUsMMseenYAjdMS2hSmUQmY2d0HLrVylmN64kxZavNXuEzcjs73vaAMZ75k8gpMbsH85nwbp57vmAHMnv2ViqfkF5GBYfSF1JLKcc539hEO97CjHhDJKGqds31Jnwxfb9spwEhhuPxPGmMWWrFoDBlWT+a6/t0HruBDisNJJ4nClBWYv1honEsJs5g/4FJWLd42chtxZL/fPhbrA9A9rBfIMLqiVEnZ6qWYuUypQqR1JZz5KnNY/vCxl2HbzdW+vzRGH7Ri0Rgy+nfs/7DV0w9/civCpxkJFnx2ekBVVikdIrQRHPgEkmrxOlaUUC0IOlDT7Br2C0SNPtEcBQxIvQjtiznqgaIqpJRCkfdrMzDLbiSU7hz2a6QxpqCJRWNosNmc7IGji20Qv19SEwQXdgyECEMMNVaZxQi3v3CZICAVL0LM38bdF/h67xxiseFVKwBASQYxE7AsqAgkUGXe9xka4bCBbl9kW8ZYijhpdIb/OmmMGWhi0RgKzPzxk6uyh060ir4BuJ0Z48oi2QTjVxCpTuR6XpEIZQQkIvhaEKFaPKIxDIDS4fcfUJqBYQCWHU0gxdRDGYRTTH2UIhMxDFlcnz9y4sX4lMaFhFJNLBplQxOLxpBw/Ldv3WcXbMcMFlInRCIIKD8LZjK/XqF6VOoERUiFQOrI4TvvGSEOsRB6CsZpkDyoAUYKJdWI2nwFDJhwymwTTUjukgGw7AZQakKPadEoE5pYNAYLk9msJXe8x8ncTigAFkEKDFGkEpQlRQO1WcxpoyIVzr/Ck4q/icI8Rg2AkMKwXymCAjMMtTmqTPPXgAhnIG0i1nv1DEDuyIn1ialNDdDEolEmNLFoDBbmybf37rAZcdQKWBFTGClBKkE5MJGpzGJqgvEbhtrISkZSLYYBUHKKFAtVm6P4crnmq3KIIiL6C6UUimJfDATMZk2EkiB3mYZGEWhi0RgsYn0HjrkpuYhEBApTWGgduE5SboMSbUTyKFYOOkqnLKgcIZpguEHUhKBSLCX8JY56UWw3QEe9rFAizWIAcp3dOxITG+Kn8IJpjGJoYtEYHBhL9R/qgs0ISMi/IhGBq1wE85SgTsSyTB6eWWzgBMMfK2wKA2NgjJnDTy/MZIxFRHMBZauREv6SaKUT0RYo7WPxiKxgA4D2s2iUBU0sGoOCXbBbCll5pL1MKq4pLMqJX3aZ+LuQMx9Hmb8Eh33IFOaUmc0Amw3/M8AQY4o09yH/iZI4vPOOJgi1TwWRZFEumYT2x5AEQR6aXDRKQBOLxmCQznf3LWeRpBJlCuOc+EBEWfaj8G2I0F5O46KqV6V68Ttxm7lpS4YZjKVgWVCndUEJ4hDr2ICJp1wFIy+Ddh5x5U/2HTXTSW0O0ygJTSwaAwdjqWNv7r2PCSPto1QL4Bq5QsRQXpko6qMJpmxScT0srGClh9sUxmw75SuWgRJHSfNXuE7tf4nYVtGOKbcD7IIFaHOYRhnQxKIxYDCGdP/xjJuHqxiplIoK4xVMMaWCiLBjSMeLLoukwpGOZaUw3J0ls5MsqiMvRhzlRHANmETC7cOhx+ql62fR0CgJnYRSY8BgNkvlenIQk07KZWleFsXcKCwyAWXpJJXi3C1iwkp1mYrbunX5PfsfGOZ5R1Kw7JTTQVPJz6KoE9aFk1TK10hNSkWIyN8HpDlaoD4Pbum+JuiXUY2S0DeJxoDBLLvBtpg7KBKlVUuECYt3yJdXH20W4xVJsG0RpeLW2f05sII1h5ixzuG5WKwx337wifJMXGWsK1PNsDIUSHFFE7FkMP1rr6ERAU0sGgOGlS1ML+1fUY/CJ2BKIlGXSZE2snmNIJJs/GrR/wIAdi4P1p+dQ8zYhuG4VixfaLFzhfJJoRx/iO+LUawDUDESUS6ZCRDtZ9EoCk0sGgNFOp/JtRT3r3BlQO1v8etLl70xLl7KfE+REL6D5RUJTzD+PlROfZdcevtm07pUIwiptGoxWS7fwmwGnhQiyaAcoqi4EpG3L94+15M7GK9P6MgwjaLQxKIxMDCWOrH7+DeCUGNZmahUCxBWGICY/dgtElXKFii25UkjgmD89cUjxfp37vtGqr52G61NPl7RS1WwWnN7Dv5UrUaAaBUDlFYzEW0GrGTKWQb7Y8wbm6ShEQ1NLBoDAmNIWVkLLDSpVxGCAYI24MmDCIokSqkUJyfVfkopFfikwggBbAaru6eVpmo2gJD2Cl2qlJ3pb7UtK0KNcF+yHGIYdvIIL4l0LV0bHKBDjjVKQBOLxoBh20wKNeYTUKoIxt2waNgxQbH5W7xylFlMIBgEznv1/jhScdG/88A9xDS7Y03jfoChz/Fu2pn+K7K7DzxUstMvp6MfEkmUIqXo7VmIZAAtWDTKgSYWjYGBIWYVGERTmNehO/WBcojOGyY73nlzlkrBOCpHTTYBUQT7kwlGWfaP5yiZzLa930kZRiY2rm7toJULQ6Pdn13e9+6+J0RGDC9JOR3/sDriyycZv52GRhnQxKIxIDDAtJk3PiSKVJhEBGFfS5T5Sy6LigRi3xYytclKpgjBgPh9ND+lcWbLngeSC2fcHqtLbSJmbCsIynXop5lltdj9uYV97+5/zNllMXIolmoFJc1f5BSTC5MuvYZGMWhi0RgQCIE4twhhQicukw2IOI4kWrWUWUY467GndlSOf4FIIJKKes4WILNt330kRpFaMONGWmPuI4Zx0J+LhBDHTMZYylmwFCzWyPKF5r5dB55gBUs0JUWSwmCUCqAyU5VaEmV9kWOr2vvXVNOLRmloYtEYKAo0ZoARCkKc91gmkAWBHFrsGMw4X0uEauHViaqsVC8h85gi7Qui0+sH50HEtjZD75a9D4EA1IyB1sQBQkDjpkOWBQuwGex8ASzPTzlM/e9OIjppMXlncB7OsSuvOGQSIgMlF6GuSnedxqiCJhaNgYEgT00DXnqQQIGoyoDnzBcjspi6o4o0efHrvc4R5Y1pEfZbnFS8N3vBVAbALtiwe/vdun74J+Dvh3DtA8UhR6gF5rdodcGKdPZDN3+J50UU5xdqL23rkpKOCNMoCk0sGgMCAcnEkjEuKsypDafKlwdEsqBT58OBwakQwXSFsPIoQ7UIUWNCHU86alIplvrFJx1FHZTrIjr1UoQh7ZNfRpm/ylMgYSXCOJIuh1QAgFAtWTRKQyeh1BgYCPqa5oy7ufwElGLCSYBLRgnim4WikiwKbYR6inDySa7e3y44L/jrxf3BPz+PvahwXCjO19+GW4eI9l7iyyCiS1yqk2+q2kKtcgDx/IqSi2p7RbuobTSxaJQBrVg0BopMrCbWHkSFAdEj8IGwglGZqAA/hxhEpcJHl6nNX/CP69f769WqxT1bYRt1GHLY9wJVnftZ2FbqrEsqFclE5n8v2cQ2ICVSwsxVLKQ4om08GWuo8v2nMQqgiUVjwDBipFN8M2ac05mLBAOgnE2SN4u5q2QnPG/yUpu/3KIQXqzeX9jkhRCRCGWJQHwzmNDRo6hpTBhcGNGRl9NG5asp7WsRtwv4ohi5+P+i2zgoQPtYNEpAE4vGgEEo6U421KC/O+tWEDApKiywqHidaHgEftDJy6levG3DZU/BKMkGYaJRkQrxzynopJm0vVd22kkE4x9PdMaLxBOokJLqo4gKqoQiYWWQiz9ORblPd+GYwTSpaJSEJhaNAYMQ0lU/OYW+7jzKc+DznbQYESY71qOUiopIPJOWPI7FaxtLxRGrMZE74Q49IZJ5DArS4AkmdO7BhuWrGLWK8BeEIJaKg1kMlptev7QZTNxXOYpETS7BeqEst3HLNKZdshrlQROLxsBB0D29dfyFh97tfnlo/hW1UuF9J6qy7FuBXw72YdYlkJ7ZCADIdvXDH7jJnVbUyHxPQUSZxICBq5hifhezPgkSo8idyKDQl1eYwYqZv0opGOkaqchHaBu9LpHS/hWN8qBfQTQGg3wsTjfX1Mfdt3Z56mEaEcElRk+JkV3hNqqyF30GKSIMXNtxCybf1bRk+sLE+BSxLduNmuLaQowCC01n7E4XzJf9bbjzD9oHn+XzBlRtIayzCzZiNSZJNTc01E0fv0IY4a7aVliGSSh6fSlSIcp1nBnMyT6goVECmlg0Bou+hRdO+hgxDK5DolKZQuxso8mDFSWboAyBsCRSoRTjFzXfmZxY9yihZBsYGvuO9ipIRSx7coefQ56BO0d5nYpMuHNBxHYAFNsD+UwOANIAuqlptNVNbVgBIhMTIshhYOuF+mKqRlqXrDObqn3DaYweaFOYxmCRr6k3n4qnYujvLcA3hwm+FkB25gtht36eMfjti5nF5DrC7Y9QoPGMSbcnJ6QeAtANALZlt2RPZuGQRmDyEp33CpOYZAbz+two81eQbLKI2cz7yHXgXlsra4HZrIlQ0g0gQ01jU920hsV2wW7OHO55TuVbGZjZS1GvbBNeRwhQUx+bAYJuaLWiUSa0YtEYCvrOuHjS1bGEUbYpTKVg4CuSsKrgVYP4th8oGVCCiYubb+ZJBYBp561m24KoTvjBjwqTGAQzmFqNyIqFP291G4RUkNgWYDZLw5lACwDy1KBthmm0O8oPXHtwpCYpEIHIiigWIEQqJGqdQ8Rd0KSiMQAQPdWoxhBhHjvQ9+V3Nxy7BwCIq0K8ftjLcOwNc3HqgzYQ6p0dEq59yCXh1Xn1lGDqOVOuNpOxl8BN0MUYazn6zpG92ZNZbpug44yuI8J6Xr0IPocIFeK3l9twHbWqjWEaqJ+angKCDv7aMsYa7by9sPdI74sqBSJGjZVRz5X5dbxbhf+eNfXmFOJMHaCJRaNsaMWiMVTkx09J/mD6mQ33BypEdLaHHdtRCoZ7iy/mE3HbTpg34ast509bJpMKANh5uyXbmw9to9qPXBfytygUSrS/BYPyv1gWA2MsLV9bQkiHETc21k2uW1bap1Ki3l0Ht1q9LiCjmnpzhiYVjcFA+1g0hgxC0NE8p/a71CD5vW3dd3ghyOKUwSzkNw46P87X4jUnxUOOp5098cZEXfxVQslO1TlZebuZ2c7JkZCvBEXrAn+LqF5kfwvhzpdfF/hBvJNWt/GP6/bkzGYpQolqPvluGqPb6pvr5p48lNnhHZPfT1F/CSLWCZuKKibpKBXtV9EYFDSxaFQE1CDbJs1M/YDGaN/uN7u+7HTo4hz2/pwsvMkffAfupYMJ1svlyQvH35VMJzbFEsYmRM3uyNBo5axGJpFKeDwMRwBKouE7f4iEQcKOeplM5AGWpcil50hmY7q5TjaHecgQStrrm2unMJs19hzp2xxFFNEKRfE5RDgCqWSgoTEIaB+LRkXBbDan62juw7s3d38r328J/pKQ30Wog+A7AWHCdpMXjPtKIhVrT9SZGwgl24qdg5WzVh7YfPRlZtkAgo5d8E+H/CdR7Yr5YBTr/M/FfSpE0dETQtAwtW5hqe8HIMVs1swYkj2d/Zv57wOBUyJ8KRKpEO74ybpYk44A0xgqNLFoDAfMXL99xYnD2UsPvtv75ULOEh3uLrmUct7HTIJJc9JfMZNGR02duYEapK2cg2d78jd0vNP5U2dfIlkEHStR1LntVe0ABWHIxCO+/cshwUWd+u7ndHPtMhqjbSivY08zxhqYjWTmRG5r8CyHv4NMqFwzEEpQUxebQggy0IMgNSoATSwawwkz12dd0dtVWNqfKTQf2dt3B2PMzeTipnNx/1Hq/hkEjS2pe82EcTRZb7aZNUYbIWgfyDH7urKfOLTtxIMkgkDCyqMY4YQVBk80kcRTsq1aucTiFPWTUrUYmBnKBHNJhiGW6c5vVTUiktpK1sdmAMhrQtGoNDSxaJwqpAs5e/HhvX0vW3kb+ZwNuxColpqUATNB0Tg9ucIw6M5I/0kJMJvN2f/28R2F/gKiSUVUC6UJRzaRFSMTUdVErnN3KJimCAE1CNKTU1OI2s9SDkwASTCYDDABZvb3WHtBgJra2BT3cHkQ5KHJRGOYoJ33GqcK3bE43TB1Xm28jLaD7uxsizXbBeY6yaUR9+Cjv8LOefWo/IAMlE58yJmDxYgxJpFJyc8MAGMpwQE/MOThEIe7S2Im62Nxab2GxrBCE4vGqcSwd2pWgaUtN8yYn7clTCpyhBb8SC7Z6V0yQgwSuUh+DUbCygURnxkDGENy0LRShWuuoSFDE4vGmIKVtxuZ2+PLkVp8Rx41jwtPLmJocTnkom7jH1+xjfIzgwnHpKVJQWNUQo+81xhLMG2LpQIHh5hjDAjn9OKzCKvWqbITR34u0oaVuw8AvcdzG6t9ITU0hgKtWDTGEszOA/0PBAMjOVUCFPG3yNFbovoQTVooW6mISsT9V4Z5zA2n0YpFY9RCE4vGmAFjSDO+Nxf8J6o6cUZK2fzltQuNyIe0PylkuBxfithO2s6BfjY1Ri30zasxlmC6eZNLOux5nwqEZTiSLIoQ1EpF3VblS0Ho+IKjx5SIRkNj1EATi8bYAWOmExZMBFIBEFIqkUTh7auIGUzcT/G2xcxhxRQLAzSvaIxaaGLRGFNgCHf80epFMn9J26mJQe1/GZg5rEQ7oklFY3RDE4vGGALJeyPnlaYulXrxl0RJRkqSifC/DI5MFPWaVjRGOTSxaIwdeE56Ll2/HBkWRS6qEfnKtsXWKckkqr4IyTjkpSPCNEYtNLFojBkQgi5/7vYI34ps/lKpkGBJBHIqRQ7RgyLD+yxerxWLxuiGHiCpMZbQN3Fq/MZigyCjQ5GJYlmqDSQyiNh/1D5V9cGmfdW+mBoag4VWLBpjCXlqEKdD5v0fxXwrg1IqxXwrQDmKhTfLBQLF2WfdOGNhtS+khsZQoIlFY0zBiJEuQkkQr8sTBBD2ZQh1EUuU03ZgZBJa7y2czwXoUfcaoxiaWDTGFIwYOowYhVVg0eNUylUqRdoSBdmUHq8SsZ77SJx0NHqueY1RDe1j0RhToJR0TJ5uXq/0Zbh/rByfircsu616PVGdh7ye2weh0MSiMeqhFYvGmAIh6DQoycjjUgZiyiJlbROtSIqnbSmibADUpY250I57jVEOTSwaYw4xEx3UILC9WbeLduwog4AG4I8ZKJkQqdpRK9q/ojGqoU1hGmMO1CDtZqKYMx0BmRQxdxUdEwNnO1IkBFllBuN9M8JwFQIYBgEh6K729dPQGCo0sWiMORCC7inTYiuURMH/RY47EZfE3Wn5JAKU5b/x9u+2qUvTKdBqRWMMQBOLxlhE3oiR9niCoHxzF4o46kuRCCAqktLtBZICQA1tBtMYO9DEojEmQQg6p7XEFoNwSgWllijTl0IUCkZsV5JMJN9KvaNWtNNeY0xAE4vGWEXeMNDeMsO4rLSZS7F0fS9q8xkEBVRsBL6STCTfSrqBznV9K1qtaIwJ6KgwjbGMbjNONhsGgWW7NYOMDJOJR1jvryORbYiCVDyuohQdgB67ojF2oBWLxpgGIehumWnMFUQDifhDucsgYsxTJMVG4ivNYq4iSjfQJmilojHGoIlFY6wjTyk6prcYKwAoSYQolxx5FAs/LmeMDLjNSMBkDQ1khjaBaYxFEMbY0PeioTHykcrn0bp/v70+0q8ylGXkurBvhQBoGEdmEIIOaFLRGIPQxKJxOiFVKGDB/v32RkCtVKLII6q9vzrCx0LUpDKFEHRCk4rGGIUmFo3TDSnLwvT9++2tQBGyiFwS8bP/r/S2ADBOk4rGaQBNLBqnI1KMobFQQHNHB1vvRxCXIgaF+avcbcaNIzMAZLRPReN0gCYWjdMWjKHRttFsWWg4fIS9PFjfSjECGtdA5hLiE4oOKdY4LaCJReO0B2NosSw0MgbzaCdbz1j5pKJaRwnQ0EDmAgClOAroxJIapxc0sWhoBEjbNppsG2nGYB47ztbzK2V/im8+c8eljGsgCwEUtELRON2hiUVDQ400Y2hgDCaAmLuEzZAiQJ4Q5w8OkeTh+E/6oMlEQ0MTi4aGhoZGZaFH3mtoaGhoVBSaWDQ0NDQ0KgpNLBoaGhoaFYUmFg0NDQ2NikITi4aGhoZGRaGJRUNDQ0OjotDEoqGhoaFRUWhi0dDQ0NCoKDSxaGhoaGhUFJpYNDQ0NDQqCk0sGhoaGhoVhSYWDQ0NDY2KQhOLhoaGhkZFoYlFQ0NDQ6Oi0MSioaGhoVFRaGLR0NDQ0Kgo/n+FwQJpPEnbzAAAAABJRU5ErkJggg=="
+        title="perseids logo"
+      />
+    </a>
+    <span>
+      <i>
+        On the Murder of Eratosthenes
+      </i>
+    </span>
+    <ul
+      className="navbar-nav ml-auto"
+    >
+      <li
+        className="nav-item"
+      >
+        <a
+          className="nav-link"
+          href="https://www.example.com/"
+        >
+          Home
+        </a>
+      </li>
+    </ul>
+  </header>,
+  <div
+    className="container pt-3"
+  >
+    <h2>
+      <span>
+        Lysias
+        ,
+        <i>
+           
+          On the Murder of Eratosthenes
+           
+        </i>
+        1-50
+      </span>
+    </h2>
+    <table
+      className="table"
+    >
+      <tbody>
+        <tr>
+          <th
+            scope="col"
+          >
+            Author
+          </th>
+          <td
+            className="publicationRow"
+          >
+            Lysias
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="col"
+          >
+            Work
+          </th>
+          <td
+            className="publicationRow"
+          >
+            On the Murder of Eratosthenes
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="col"
+          >
+            Locus
+          </th>
+          <td
+            className="publicationRow"
+          >
+            1-50
+             
+            <a
+              href="../on-the-murder-of-eratosthenes"
+            >
+              (See all)
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="col"
+          >
+            Editors
+          </th>
+          <td
+            className="publicationRow"
+          >
+            Vanessa Gorman
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="col"
+          >
+            Link
+          </th>
+          <td>
+            <a
+              href="https://www.example.com"
+            >
+              https://www.example.com
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <th
+            scope="col"
+          >
+            Notes
+          </th>
+          <td
+            className="publicationRow"
+          >
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <div
+      className="treebankWrapper"
+    >
+      <div>
+        Loading...
+      </div>
+    </div>
+    <div
+      className="pt-1 pb-4 text-right"
+    >
+      <a
+        href="https://www.example.com/xml/lysias-1-1-50.xml"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        View full XML
       </a>
     </div>
   </div>,
@@ -9409,7 +9638,7 @@ Array [
       >
         <a
           className="nav-link"
-          href="/"
+          href="https://www.example.com/"
         >
           Home
         </a>
@@ -9449,7 +9678,7 @@ Array [
       >
         <h2>
           <a
-            href="/"
+            href="https://www.example.com/"
           >
             Return to homepage
           </a>
@@ -10272,7 +10501,7 @@ Array [
           </a>
            or view a 
           <a
-            href="/on-the-murder-of-eratosthenes-1-50/1"
+            href="https://www.example.com/on-the-murder-of-eratosthenes-1-50/1"
           >
             treebank
           </a>
@@ -11786,7 +12015,7 @@ Array [
           file (doing so requires a local clone of your GitHub respository). You can also add additional files and publications, and
            
           <a
-            href="/examples/alpheios-integration"
+            href="https://www.example.com/examples/alpheios-integration"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -11948,7 +12177,7 @@ Array [
           </a>
            or view a 
           <a
-            href="/on-the-murder-of-eratosthenes-1-50/1"
+            href="https://www.example.com/on-the-murder-of-eratosthenes-1-50/1"
           >
             treebank
           </a>
@@ -12393,7 +12622,7 @@ Array [
           </a>
            or view a 
           <a
-            href="/on-the-murder-of-eratosthenes-1-50/1"
+            href="https://www.example.com/on-the-murder-of-eratosthenes-1-50/1"
           >
             treebank
           </a>

--- a/src/components/Publication/Publication.js
+++ b/src/components/Publication/Publication.js
@@ -110,6 +110,7 @@ class Publication extends Component {
     const {
       logo,
       link,
+      treebankReact,
       publicationPath,
       author,
       work,
@@ -170,11 +171,13 @@ class Publication extends Component {
               location={location}
               match={match}
               arethusa={this.arethusa}
+              treebankReact={treebankReact}
+              setSubdoc={(s) => this.setState({ subDoc: s })}
             />
           </div>
           <div className="pt-1 pb-4 text-right">
             <a href={`${process.env.PUBLIC_URL}/xml/${xml}`} target="_blank" rel="noopener noreferrer">
-              View XML
+              View full XML
             </a>
           </div>
         </div>
@@ -186,6 +189,7 @@ class Publication extends Component {
 Publication.propTypes = {
   logo: PropTypes.string,
   link: PropTypes.string,
+  treebankReact: PropTypes.bool,
   publicationPath: PropTypes.string.isRequired,
   author: PropTypes.string.isRequired,
   work: PropTypes.string.isRequired,
@@ -205,6 +209,7 @@ Publication.propTypes = {
 Publication.defaultProps = {
   logo: undefined,
   link: undefined,
+  treebankReact: false,
   publicationLink: undefined,
   notes: undefined,
 };

--- a/src/components/PublicationDirector/PublicationDirector.js
+++ b/src/components/PublicationDirector/PublicationDirector.js
@@ -10,7 +10,7 @@ class PublicationDirector extends Component {
 
     const { config } = props;
     const argsLookup = {};
-    const { logo, link } = config;
+    const { logo, link, treebankReact } = config;
 
     config.collections.forEach((collection) => {
       (collection.publications || []).forEach((publication) => {
@@ -31,6 +31,7 @@ class PublicationDirector extends Component {
           argsLookup[path] = {
             logo,
             link,
+            treebankReact,
             publicationPath,
             author,
             work,

--- a/src/components/Treebank/Treebank.js
+++ b/src/components/Treebank/Treebank.js
@@ -1,77 +1,27 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import { chunksType, publicationMatchType, locationType } from '../../lib/types';
 
-import styles from './Treebank.module.css';
-
 import ArethusaWrapper from '../ArethusaWrapper';
-import ControlPanel from '../ControlPanel';
-import TreebankStyles from '../TreebankStyles';
 
-import { parse, linkParams } from '../../lib/params';
+import TreebankArethusa from './TreebankArethusa';
+import TreebankReact from './TreebankReact';
 
-class Treebank extends Component {
-  constructor(props) {
-    super(props);
-
-    this.additionalArgs = this.additionalArgs.bind(this);
-    this.linkQuery = this.linkQuery.bind(this);
-    this.renderArethusa = this.renderArethusa.bind(this);
-  }
-
-  componentDidMount() {
-    this.renderArethusa();
-  }
-
-  componentDidUpdate() {
-    this.renderArethusa();
-  }
-
-  additionalArgs() {
-    const { location: { search } } = this.props;
-
-    return parse(search);
-  }
-
-  linkQuery() {
-    const { location: { search } } = this.props;
-
-    return linkParams(search);
-  }
-
-  renderArethusa() {
-    const {
-      xml,
-      match: { params: { chunk } },
-      arethusa: { render },
-    } = this.props;
-    const additionalArgs = this.additionalArgs();
-
-    render(xml, chunk, additionalArgs);
-  }
-
-  render() {
-    const { chunks, match } = this.props;
-    const linkQuery = this.linkQuery();
-    const fullQuery = this.additionalArgs();
-
+const Treebank = ({
+  treebankReact,
+  ...props
+}) => {
+  if (treebankReact) {
     return (
-      <>
-        <ControlPanel
-          match={match}
-          chunks={chunks}
-          fullQuery={fullQuery}
-          linkQuery={linkQuery}
-        />
-        <div className="__artsa">
-          <div id="treebank_container" className={styles.treebankContainer} />
-        </div>
-        <TreebankStyles />
-      </>
+      <TreebankReact {...props} />
     );
   }
-}
+
+  return (
+    <TreebankArethusa {...props} />
+  );
+};
 
 Treebank.propTypes = {
   arethusa: PropTypes.instanceOf(ArethusaWrapper).isRequired,
@@ -79,6 +29,8 @@ Treebank.propTypes = {
   match: publicationMatchType.isRequired,
   location: locationType.isRequired,
   xml: PropTypes.string.isRequired,
+  treebankReact: PropTypes.bool.isRequired,
+  setSubdoc: PropTypes.func.isRequired,
 };
 
 export default Treebank;

--- a/src/components/Treebank/Treebank.module.css
+++ b/src/components/Treebank/Treebank.module.css
@@ -1,3 +1,14 @@
 .treebankContainer {
   position: relative;
 }
+
+.text p {
+  margin-bottom: 0.7rem;
+  margin-top: 0.7rem;
+}
+
+.graph {
+  display: flex;
+  height: 60vh;
+  min-height: 500px;
+}

--- a/src/components/Treebank/TreebankArethusa.js
+++ b/src/components/Treebank/TreebankArethusa.js
@@ -1,0 +1,84 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import { chunksType, publicationMatchType, locationType } from '../../lib/types';
+
+import styles from './Treebank.module.css';
+
+import ArethusaWrapper from '../ArethusaWrapper';
+import ControlPanel from '../ControlPanel';
+import TreebankStyles from '../TreebankStyles';
+
+import { parse, linkParams } from '../../lib/params';
+
+class Treebank extends Component {
+  constructor(props) {
+    super(props);
+
+    this.additionalArgs = this.additionalArgs.bind(this);
+    this.linkQuery = this.linkQuery.bind(this);
+    this.renderArethusa = this.renderArethusa.bind(this);
+  }
+
+  componentDidMount() {
+    this.renderArethusa();
+  }
+
+  componentDidUpdate() {
+    this.renderArethusa();
+  }
+
+  additionalArgs() {
+    const { location: { search } } = this.props;
+
+    return parse(search);
+  }
+
+  linkQuery() {
+    const { location: { search } } = this.props;
+
+    return linkParams(search);
+  }
+
+  renderArethusa() {
+    const {
+      xml,
+      match: { params: { chunk } },
+      arethusa: { render },
+    } = this.props;
+    const additionalArgs = this.additionalArgs();
+
+    render(xml, chunk, additionalArgs);
+  }
+
+  render() {
+    const { chunks, match } = this.props;
+    const linkQuery = this.linkQuery();
+    const fullQuery = this.additionalArgs();
+
+    return (
+      <>
+        <ControlPanel
+          match={match}
+          chunks={chunks}
+          fullQuery={fullQuery}
+          linkQuery={linkQuery}
+        />
+        <div className="__artsa">
+          <div id="treebank_container" className={styles.treebankContainer} />
+        </div>
+        <TreebankStyles />
+      </>
+    );
+  }
+}
+
+Treebank.propTypes = {
+  arethusa: PropTypes.instanceOf(ArethusaWrapper).isRequired,
+  chunks: chunksType.isRequired,
+  match: publicationMatchType.isRequired,
+  location: locationType.isRequired,
+  xml: PropTypes.string.isRequired,
+};
+
+export default Treebank;

--- a/src/components/Treebank/TreebankReact.js
+++ b/src/components/Treebank/TreebankReact.js
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Treebank as TB,
+  Sentence,
+  Text,
+  Graph,
+  PartOfSpeech,
+  Xml,
+  Collapse,
+} from 'treebank-react';
+import fetch from 'cross-fetch';
+
+import { chunksType, publicationMatchType, locationType } from '../../lib/types';
+
+import styles from './Treebank.module.css';
+
+import ControlPanel from '../ControlPanel';
+
+import { parse, linkParams } from '../../lib/params';
+
+class Treebank extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loadedXml: false,
+    };
+
+    this.additionalArgs = this.additionalArgs.bind(this);
+    this.linkQuery = this.linkQuery.bind(this);
+  }
+
+  componentDidMount() {
+    const { xml } = this.props;
+
+    fetch(`${process.env.PUBLIC_URL}/xml/${xml}`)
+      .then((response) => response.text())
+      .then((loadedXml) => {
+        this.setState({ loadedXml });
+      });
+  }
+
+  additionalArgs() {
+    const { location: { search } } = this.props;
+
+    return parse(search);
+  }
+
+  linkQuery() {
+    const { location: { search } } = this.props;
+
+    return linkParams(search);
+  }
+
+  render() {
+    const { chunks, match } = this.props;
+    const { params: { chunk } } = match;
+    const linkQuery = this.linkQuery();
+    const fullQuery = this.additionalArgs();
+
+    const { loadedXml } = this.state;
+    const { setSubdoc } = this.props;
+
+    if (!loadedXml) {
+      return (
+        <div>
+          Loading...
+        </div>
+      );
+    }
+
+    return (
+      <>
+        <ControlPanel
+          match={match}
+          chunks={chunks}
+          fullQuery={fullQuery}
+          linkQuery={linkQuery}
+        />
+        <div className="mb-4">
+          <TB treebank={loadedXml}>
+            <Sentence id={chunk} callback={({ $: { subdoc } }) => setSubdoc(subdoc)}>
+              <div className={styles.text}>
+                <Text />
+              </div>
+              <div className={styles.graph}>
+                <Graph />
+              </div>
+              <PartOfSpeech />
+              <Collapse title="XML">
+                <Xml />
+              </Collapse>
+            </Sentence>
+          </TB>
+        </div>
+      </>
+    );
+  }
+}
+
+Treebank.propTypes = {
+  chunks: chunksType.isRequired,
+  match: publicationMatchType.isRequired,
+  location: locationType.isRequired,
+  xml: PropTypes.string.isRequired,
+  setSubdoc: PropTypes.func.isRequired,
+};
+
+export default Treebank;

--- a/src/config.json
+++ b/src/config.json
@@ -6,6 +6,7 @@
   "report": "https://github.com/perseids-publications/treebank-template/issues",
   "github": "https://github.com/perseids-publications/treebank-template/",
   "twitter": "https://twitter.com/PerseidsProject",
+  "treebankReact": true,
   "collections": [
     {
       "title": "Information",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'perseids-react-components/build/css/index.css';
+import 'treebank-react/build/index.css';
 
 import './index.css';
 import App from './components/App';

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -1,5 +1,11 @@
 import {
-  arrayOf, number, shape, string, oneOfType, element,
+  arrayOf,
+  bool,
+  element,
+  number,
+  oneOfType,
+  shape,
+  string,
 } from 'prop-types';
 
 export const chunksType = shape({
@@ -42,6 +48,7 @@ export const configType = shape({
   github: string,
   twitter: string,
   collections: arrayOf(collectionType).isRequired,
+  treebankReact: bool,
 });
 
 export const locationType = shape({

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -28,3 +28,5 @@ global.arethusaApiGetSubdocFun = () => { throw 'Error' };
 global.crypto = {
   getRandomValues: array => array.map(() => Math.random()),
 };
+
+process.env.PUBLIC_URL = 'https://www.example.com';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3034,7 +3034,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.18.0, commander@^2.20.0:
+commander@2, commander@^2.11.0, commander@^2.18.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -3272,6 +3272,13 @@ create-react-context@^0.3.0:
   dependencies:
     gud "^1.0.0"
     warning "^4.0.3"
+
+cross-fetch@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
+  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
+  dependencies:
+    node-fetch "2.6.1"
 
 cross-spawn@7.0.1:
   version "7.0.1"
@@ -3531,6 +3538,494 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
+
+d3-array@2, d3-array@>=2.5, d3-array@^2.3.0:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.9.1.tgz#f355cc72b46c8649b3f9212029e2d681cb5b9643"
+  integrity sha512-Ob7RdOtkqsjx1NWyQHMFLtCSk6/aKTxDdC4ZIolX+O+mDD2RzrsYgAyc0WGAlfYFVELLSilS7w8BtE3PKM8bHg==
+
+d3-axis@1:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"
+  integrity sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==
+
+d3-axis@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-2.0.0.tgz#40aebb65626ffe6d95e9441fbf9194274b328a8b"
+  integrity sha512-9nzB0uePtb+u9+dWir+HTuEAKJOEUYJoEwbJPsZ1B4K3iZUgzJcSENQ05Nj7S4CIfbZZ8/jQGoUzGKFznBhiiQ==
+
+d3-brush@1:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.1.6.tgz#b0a22c7372cabec128bdddf9bddc058592f89e9b"
+  integrity sha512-7RW+w7HfMCPyZLifTz/UnJmI5kdkXtpCbombUSs8xniAyo0vIbrDzDwUJB6eJOgl9u5DQOt2TQlYumxzD1SvYA==
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3-brush@2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-2.1.0.tgz#adadfbb104e8937af142e9a6e2028326f0471065"
+  integrity sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==
+  dependencies:
+    d3-dispatch "1 - 2"
+    d3-drag "2"
+    d3-interpolate "1 - 2"
+    d3-selection "2"
+    d3-transition "2"
+
+d3-chord@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.6.tgz#309157e3f2db2c752f0280fedd35f2067ccbb15f"
+  integrity sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==
+  dependencies:
+    d3-array "1"
+    d3-path "1"
+
+d3-chord@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-2.0.0.tgz#32491b5665391180560f738e5c1ccd1e3c47ebae"
+  integrity sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==
+  dependencies:
+    d3-path "1 - 2"
+
+d3-collection@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
+  integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
+
+d3-color@1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
+  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
+
+"d3-color@1 - 2", d3-color@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
+  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
+
+d3-contour@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-1.3.2.tgz#652aacd500d2264cb3423cee10db69f6f59bead3"
+  integrity sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==
+  dependencies:
+    d3-array "^1.1.1"
+
+d3-contour@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-2.0.0.tgz#80ee834988563e3bea9d99ddde72c0f8c089ea40"
+  integrity sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==
+  dependencies:
+    d3-array "2"
+
+d3-delaunay@5:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-5.3.0.tgz#b47f05c38f854a4e7b3cea80e0bb12e57398772d"
+  integrity sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==
+  dependencies:
+    delaunator "4"
+
+d3-dispatch@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
+  integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
+
+"d3-dispatch@1 - 2", d3-dispatch@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-2.0.0.tgz#8a18e16f76dd3fcaef42163c97b926aa9b55e7cf"
+  integrity sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==
+
+d3-drag@1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.5.tgz#2537f451acd39d31406677b7dc77c82f7d988f70"
+  integrity sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==
+  dependencies:
+    d3-dispatch "1"
+    d3-selection "1"
+
+d3-drag@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-2.0.0.tgz#9eaf046ce9ed1c25c88661911c1d5a4d8eb7ea6d"
+  integrity sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==
+  dependencies:
+    d3-dispatch "1 - 2"
+    d3-selection "2"
+
+d3-dsv@1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.2.0.tgz#9d5f75c3a5f8abd611f74d3f5847b0d4338b885c"
+  integrity sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==
+  dependencies:
+    commander "2"
+    iconv-lite "0.4"
+    rw "1"
+
+"d3-dsv@1 - 2", d3-dsv@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-2.0.0.tgz#b37b194b6df42da513a120d913ad1be22b5fe7c5"
+  integrity sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==
+  dependencies:
+    commander "2"
+    iconv-lite "0.4"
+    rw "1"
+
+d3-ease@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.7.tgz#9a834890ef8b8ae8c558b2fe55bd57f5993b85e2"
+  integrity sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==
+
+"d3-ease@1 - 2", d3-ease@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-2.0.0.tgz#fd1762bfca00dae4bacea504b1d628ff290ac563"
+  integrity sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==
+
+d3-fetch@1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-1.2.0.tgz#15ce2ecfc41b092b1db50abd2c552c2316cf7fc7"
+  integrity sha512-yC78NBVcd2zFAyR/HnUiBS7Lf6inSCoWcSxFfw8FYL7ydiqe80SazNwoffcqOfs95XaLo7yebsmQqDKSsXUtvA==
+  dependencies:
+    d3-dsv "1"
+
+d3-fetch@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-2.0.0.tgz#ecd7ef2128d9847a3b41b548fec80918d645c064"
+  integrity sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==
+  dependencies:
+    d3-dsv "1 - 2"
+
+d3-force@1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-1.2.1.tgz#fd29a5d1ff181c9e7f0669e4bd72bdb0e914ec0b"
+  integrity sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==
+  dependencies:
+    d3-collection "1"
+    d3-dispatch "1"
+    d3-quadtree "1"
+    d3-timer "1"
+
+d3-force@2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-2.1.1.tgz#f20ccbf1e6c9e80add1926f09b51f686a8bc0937"
+  integrity sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==
+  dependencies:
+    d3-dispatch "1 - 2"
+    d3-quadtree "1 - 2"
+    d3-timer "1 - 2"
+
+d3-format@1:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.5.tgz#374f2ba1320e3717eb74a9356c67daee17a7edb4"
+  integrity sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==
+
+"d3-format@1 - 2", d3-format@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-2.0.0.tgz#a10bcc0f986c372b729ba447382413aabf5b0767"
+  integrity sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==
+
+d3-geo@1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.12.1.tgz#7fc2ab7414b72e59fbcbd603e80d9adc029b035f"
+  integrity sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==
+  dependencies:
+    d3-array "1"
+
+d3-geo@2:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-2.0.1.tgz#2437fdfed3fe3aba2812bd8f30609cac83a7ee39"
+  integrity sha512-M6yzGbFRfxzNrVhxDJXzJqSLQ90q1cCyb3EWFZ1LF4eWOBYxFypw7I/NFVBNXKNqxv1bqLathhYvdJ6DC+th3A==
+  dependencies:
+    d3-array ">=2.5"
+
+d3-hierarchy@1:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz#2f6bee24caaea43f8dc37545fa01628559647a83"
+  integrity sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==
+
+d3-hierarchy@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz#dab88a58ca3e7a1bc6cab390e89667fcc6d20218"
+  integrity sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw==
+
+d3-interpolate@1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
+  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
+  dependencies:
+    d3-color "1"
+
+"d3-interpolate@1 - 2", "d3-interpolate@1.2.0 - 2", d3-interpolate@2:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-2.0.1.tgz#98be499cfb8a3b94d4ff616900501a64abc91163"
+  integrity sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==
+  dependencies:
+    d3-color "1 - 2"
+
+d3-path@1:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+"d3-path@1 - 2", d3-path@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-2.0.0.tgz#55d86ac131a0548adae241eebfb56b4582dd09d8"
+  integrity sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==
+
+d3-polygon@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-1.0.6.tgz#0bf8cb8180a6dc107f518ddf7975e12abbfbd38e"
+  integrity sha512-k+RF7WvI08PC8reEoXa/w2nSg5AUMTi+peBD9cmFc+0ixHfbs4QmxxkarVal1IkVkgxVuk9JSHhJURHiyHKAuQ==
+
+d3-polygon@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-2.0.0.tgz#13608ef042fbec625ba1598327564f03c0396d8e"
+  integrity sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ==
+
+d3-quadtree@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.7.tgz#ca8b84df7bb53763fe3c2f24bd435137f4e53135"
+  integrity sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==
+
+"d3-quadtree@1 - 2", d3-quadtree@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-2.0.0.tgz#edbad045cef88701f6fee3aee8e93fb332d30f9d"
+  integrity sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw==
+
+d3-random@1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-1.1.2.tgz#2833be7c124360bf9e2d3fd4f33847cfe6cab291"
+  integrity sha512-6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ==
+
+d3-random@2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-2.2.2.tgz#5eebd209ef4e45a2b362b019c1fb21c2c98cbb6e"
+  integrity sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw==
+
+d3-scale-chromatic@1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz#54e333fc78212f439b14641fb55801dd81135a98"
+  integrity sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==
+  dependencies:
+    d3-color "1"
+    d3-interpolate "1"
+
+d3-scale-chromatic@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz#c13f3af86685ff91323dc2f0ebd2dabbd72d8bab"
+  integrity sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==
+  dependencies:
+    d3-color "1 - 2"
+    d3-interpolate "1 - 2"
+
+d3-scale@2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.2.2.tgz#4e880e0b2745acaaddd3ede26a9e908a9e17b81f"
+  integrity sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-scale@3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-3.2.3.tgz#be380f57f1f61d4ff2e6cbb65a40593a51649cfd"
+  integrity sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==
+  dependencies:
+    d3-array "^2.3.0"
+    d3-format "1 - 2"
+    d3-interpolate "1.2.0 - 2"
+    d3-time "1 - 2"
+    d3-time-format "2 - 3"
+
+d3-selection@1, d3-selection@^1.1.0:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.2.tgz#dcaa49522c0dbf32d6c1858afc26b6094555bc5c"
+  integrity sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==
+
+d3-selection@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-2.0.0.tgz#94a11638ea2141b7565f883780dabc7ef6a61066"
+  integrity sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==
+
+d3-shape@1:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+  dependencies:
+    d3-path "1"
+
+d3-shape@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-2.0.0.tgz#2331b62fa784a2a1daac47a7233cfd69301381fd"
+  integrity sha512-djpGlA779ua+rImicYyyjnOjeubyhql1Jyn1HK0bTyawuH76UQRWXd+pftr67H6Fa8hSwetkgb/0id3agKWykw==
+  dependencies:
+    d3-path "1 - 2"
+
+d3-time-format@2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.3.0.tgz#107bdc028667788a8924ba040faf1fbccd5a7850"
+  integrity sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==
+  dependencies:
+    d3-time "1"
+
+"d3-time-format@2 - 3", d3-time-format@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-3.0.0.tgz#df8056c83659e01f20ac5da5fdeae7c08d5f1bb6"
+  integrity sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==
+  dependencies:
+    d3-time "1 - 2"
+
+d3-time@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
+  integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
+
+"d3-time@1 - 2", d3-time@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-2.0.0.tgz#ad7c127d17c67bd57a4c61f3eaecb81108b1e0ab"
+  integrity sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q==
+
+d3-timer@1:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
+  integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
+
+"d3-timer@1 - 2", d3-timer@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-2.0.0.tgz#055edb1d170cfe31ab2da8968deee940b56623e6"
+  integrity sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==
+
+d3-transition@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.3.2.tgz#a98ef2151be8d8600543434c1ca80140ae23b398"
+  integrity sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==
+  dependencies:
+    d3-color "1"
+    d3-dispatch "1"
+    d3-ease "1"
+    d3-interpolate "1"
+    d3-selection "^1.1.0"
+    d3-timer "1"
+
+d3-transition@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-2.0.0.tgz#366ef70c22ef88d1e34105f507516991a291c94c"
+  integrity sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==
+  dependencies:
+    d3-color "1 - 2"
+    d3-dispatch "1 - 2"
+    d3-ease "1 - 2"
+    d3-interpolate "1 - 2"
+    d3-timer "1 - 2"
+
+d3-voronoi@1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.4.tgz#dd3c78d7653d2bb359284ae478645d95944c8297"
+  integrity sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==
+
+d3-zoom@1:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.8.3.tgz#b6a3dbe738c7763121cd05b8a7795ffe17f4fc0a"
+  integrity sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3-zoom@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-2.0.0.tgz#f04d0afd05518becce879d04709c47ecd93fba54"
+  integrity sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==
+  dependencies:
+    d3-dispatch "1 - 2"
+    d3-drag "2"
+    d3-interpolate "1 - 2"
+    d3-selection "2"
+    d3-transition "2"
+
+d3@^5.14:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-5.16.0.tgz#9c5e8d3b56403c79d4ed42fbd62f6113f199c877"
+  integrity sha512-4PL5hHaHwX4m7Zr1UapXW23apo6pexCgdetdJ5kTmADpG/7T9Gkxw0M0tf/pjoB63ezCCm0u5UaFYy2aMt0Mcw==
+  dependencies:
+    d3-array "1"
+    d3-axis "1"
+    d3-brush "1"
+    d3-chord "1"
+    d3-collection "1"
+    d3-color "1"
+    d3-contour "1"
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-dsv "1"
+    d3-ease "1"
+    d3-fetch "1"
+    d3-force "1"
+    d3-format "1"
+    d3-geo "1"
+    d3-hierarchy "1"
+    d3-interpolate "1"
+    d3-path "1"
+    d3-polygon "1"
+    d3-quadtree "1"
+    d3-random "1"
+    d3-scale "2"
+    d3-scale-chromatic "1"
+    d3-selection "1"
+    d3-shape "1"
+    d3-time "1"
+    d3-time-format "2"
+    d3-timer "1"
+    d3-transition "1"
+    d3-voronoi "1"
+    d3-zoom "1"
+
+d3@^6.2.0:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-6.3.1.tgz#c5fe6c7abff432826775a9e04db80b5f2e22eb1c"
+  integrity sha512-rbaoA67o2N4lO1TCuvrTGQdowNb3zT0z2ygg6TLmJZAd7TRPg+lhbfDOVwQUAgdbRD+73kg2FrEQ9HLiap5H2w==
+  dependencies:
+    d3-array "2"
+    d3-axis "2"
+    d3-brush "2"
+    d3-chord "2"
+    d3-color "2"
+    d3-contour "2"
+    d3-delaunay "5"
+    d3-dispatch "2"
+    d3-drag "2"
+    d3-dsv "2"
+    d3-ease "2"
+    d3-fetch "2"
+    d3-force "2"
+    d3-format "2"
+    d3-geo "2"
+    d3-hierarchy "2"
+    d3-interpolate "2"
+    d3-path "2"
+    d3-polygon "2"
+    d3-quadtree "2"
+    d3-random "2"
+    d3-scale "3"
+    d3-scale-chromatic "2"
+    d3-selection "2"
+    d3-shape "2"
+    d3-time "2"
+    d3-time-format "3"
+    d3-timer "2"
+    d3-transition "2"
+    d3-zoom "2"
+
 d@1, d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
@@ -3538,6 +4033,24 @@ d@1, d@^1.0.1:
   dependencies:
     es5-ext "^0.10.50"
     type "^1.0.1"
+
+dagre-d3@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/dagre-d3/-/dagre-d3-0.6.4.tgz#0728d5ce7f177ca2337df141ceb60fbe6eeb7b29"
+  integrity sha512-e/6jXeCP7/ptlAM48clmX4xTZc5Ek6T6kagS7Oz2HrYSdqcLZFLqpAfh7ldbZRFfxCZVyh61NEPR08UQRVxJzQ==
+  dependencies:
+    d3 "^5.14"
+    dagre "^0.8.5"
+    graphlib "^2.1.8"
+    lodash "^4.17.15"
+
+dagre@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/dagre/-/dagre-0.8.5.tgz#ba30b0055dac12b6c1fcc247817442777d06afee"
+  integrity sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==
+  dependencies:
+    graphlib "^2.1.8"
+    lodash "^4.17.15"
 
 damerau-levenshtein@^1.0.4:
   version "1.0.6"
@@ -3657,6 +4170,11 @@ del@^4.1.1:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
+
+delaunator@4:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-4.0.1.tgz#3d779687f57919a7a418f8ab947d3bddb6846957"
+  integrity sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -5002,6 +5520,13 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
+graphlib@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.8.tgz#5761d414737870084c92ec7b5dbcb0592c9d35da"
+  integrity sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==
+  dependencies:
+    lodash "^4.17.15"
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -5345,7 +5870,7 @@ humanize-url@^1.0.0:
     normalize-url "^1.0.0"
     strip-url-auth "^1.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -7179,6 +7704,11 @@ no-case@^3.0.3:
   dependencies:
     lower-case "^2.0.1"
     tslib "^1.10.0"
+
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -9471,6 +10001,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
+
 rxjs@^6.5.3, rxjs@^6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
@@ -9531,7 +10066,7 @@ sass-loader@8.0.2:
     schema-utils "^2.6.1"
     semver "^6.3.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -10485,6 +11020,17 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+treebank-react@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/treebank-react/-/treebank-react-0.2.1.tgz#1127a84e3dbfe41749cf67cfd3ee599696569b5a"
+  integrity sha512-Rcl6mf2bZGddCiVvOZw/MIyxUhGqvhhsR000Id9PAt+9BZSNYpcaOaogELQiNOiP9IO9i4EhiygPJ450Y0u2Dg==
+  dependencies:
+    cross-fetch "^3.0.6"
+    d3 "^6.2.0"
+    dagre-d3 "^0.6.4"
+    prop-types "^15.7.2"
+    xml2js "^0.4.23"
+
 trim-repeated@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
@@ -11338,6 +11884,19 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml2js@^0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlchars@^2.1.1:
   version "2.2.0"


### PR DESCRIPTION
* Add a configuration option for using the `treebank-react` library. If `treebankReact` is set to `true` in `config.json`, then use the library. Otherwise, use `arethusa-widget`.
* Split `Treebank.js` into `TreebankArethusa.js` and `TreebankReact.js`. `TreebankReact.js` renders the treebank using `treebank-react` and `TreebankArethusa.js` renders the treebank with `arethusa-widget`.
* Change "View XML" to "View full XML" in the link that shows the XML. The reasoning behind this change is that the sentence-level XML is now being displayed by `treebank-react`.
* Update the tests to set `process.env.PUBLIC_URL` so that everything works with `fetch`. This change isn't that important, but it creates a lot of noise in the diff.

The changes involving the `treebankReact` configuration should be reverted (except with `Treebank.js` replaced with the code in `TreebankReact.js`) in `v5`. Other files only used by Arethusa like `TreebankStyles/*` should also be removed.

---

<img width="1167" alt="Screen Shot 2020-12-29 at 4 12 28 PM" src="https://user-images.githubusercontent.com/3039310/103316746-75f9ff80-49f7-11eb-9cb3-5f97549e91e0.png">
