### PR TITLE
Update embedded API for Treebank React (1/3)

### DIFF
--- a/src/components/TreebankService/TreebankService.js
+++ b/src/components/TreebankService/TreebankService.js
@@ -67,7 +67,6 @@ class TreebankService extends Component {
           responseFn(error(request, `Unsupported request: ${name}`, ResponseMessage.errorCodes.UNKNOWN_REQUEST));
           break;
         case 'refreshView':
-          responseFn(error(request, `Unsupported request: ${name}`, ResponseMessage.errorCodes.UNKNOWN_REQUEST));
           break;
         case 'findWord':
           responseFn(error(request, `Unsupported request: ${name}`, ResponseMessage.errorCodes.UNKNOWN_REQUEST));

--- a/src/spec/__mocks__/alpheios-messaging.js
+++ b/src/spec/__mocks__/alpheios-messaging.js
@@ -1,0 +1,27 @@
+function MessagingService(_name, { receiverCB }) {
+  global.sendRequestToMock = receiverCB;
+}
+
+const ResponseMessage = {
+  errorCodes: {
+    SERVICE_UNINITIALIZED: 'SERVICE_UNINITIALIZED',
+    UNKNOWN_REQUEST: 'UNKNOWN_REQUEST',
+    INTERNAL_ERROR: 'INTERNAL_ERROR',
+  },
+  Error: (request, error) => ({ type: 'error', request, error }),
+  Success: (request, message) => ({ type: 'success', request, message }),
+};
+
+function WindowIframeDestination({ receiverCB }) {
+  return {
+    receiverCB,
+    deregister: () => {},
+  };
+}
+WindowIframeDestination.commModes = { RECEIVE: 'RECEIVE' };
+
+export {
+  MessagingService,
+  ResponseMessage,
+  WindowIframeDestination,
+};

--- a/src/spec/__mocks__/treebank-react.js
+++ b/src/spec/__mocks__/treebank-react.js
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
 
-let treebank; let id; let
-  highlight;
+let treebank;
+let id;
+let highlight;
 
 const hash = (string) => (
   string.split('').reduce(

--- a/src/spec/components/Embedded/Embedded.test.js
+++ b/src/spec/components/Embedded/Embedded.test.js
@@ -8,9 +8,9 @@ import config from '../../config.test.json';
 import treebanks from '../../treebanks.test.json';
 
 import Embedded from '../../../components/Embedded';
-// import TreebankService from '../../../components/TreebankService';
 
 jest.mock('treebank-react');
+jest.mock('alpheios-messaging');
 
 const server = setupServer(
   rest.get(`${process.env.PUBLIC_URL}/xml/lysias-1-1-50.xml`, (req, res, ctx) => (
@@ -37,39 +37,50 @@ it('renders an embedded publication', async () => {
   expect(container).toMatchSnapshot();
 });
 
-// it('provides an API to communicate with an embedded publication', () => {
-//   const component = (
-//     <MemoryRouter initialEntries={['/embed/on-the-murder-of-eratosthenes-1-50/1']}>
-//       <Embedded config={config} />
-//     </MemoryRouter>
-//   );
-//   const tree = renderer.create(component);
-//   const { instance: { messageHandler } } = tree.root.findByType(TreebankService);
-//
-//   messageHandler(
-//     { ID: 'test', body: { gotoSentence: { sentenceId: '5' } } },
-//     () => {},
-//   );
-//
-//   expect(tree).toMatchSnapshot();
-// });
-//
-// it('the API can be used to select words', () => {
-//   const component = (
-//     <MemoryRouter initialEntries={['/embed/on-the-murder-of-eratosthenes-1-50/1']}>
-//       <Embedded config={config} />
-//     </MemoryRouter>
-//   );
-//   const tree = renderer.create(component);
-//   const { instance: { messageHandler } } = tree.root.findByType(TreebankService);
-//
-//   messageHandler(
-//     { ID: 'test', body: { gotoSentence: { sentenceId: '5', wordIds: ['12'] } } },
-//     () => {},
-//   );
-//
-//   expect(tree).toMatchSnapshot();
-// });
+it('the API supports gotoSentence', async () => {
+  const component = (
+    <MemoryRouter initialEntries={['/embed/on-the-murder-of-eratosthenes-1-50/1']}>
+      <Embedded config={config} />
+    </MemoryRouter>
+  );
+  const { container, queryByText } = render(component);
+  const request = { ID: 'test', body: { gotoSentence: { sentenceId: '5' } } };
+
+  await waitForElementToBeRemoved(() => queryByText('Loading...'));
+  global.sendRequestToMock(request, () => {});
+
+  expect(container).toMatchSnapshot();
+});
+
+it('the API supports gotoSentence with highlighted words', async () => {
+  const component = (
+    <MemoryRouter initialEntries={['/embed/on-the-murder-of-eratosthenes-1-50/1']}>
+      <Embedded config={config} />
+    </MemoryRouter>
+  );
+  const { container, queryByText } = render(component);
+  const request = { ID: 'test', body: { gotoSentence: { sentenceId: '5', wordIds: ['12'] } } };
+
+  await waitForElementToBeRemoved(() => queryByText('Loading...'));
+  global.sendRequestToMock(request, () => {});
+
+  expect(container).toMatchSnapshot();
+});
+
+it('the API performs a no-op for refreshView', async () => {
+  const component = (
+    <MemoryRouter initialEntries={['/embed/on-the-murder-of-eratosthenes-1-50/1']}>
+      <Embedded config={config} />
+    </MemoryRouter>
+  );
+  const { container, queryByText } = render(component);
+  const request = { ID: 'test', body: { refreshView: true } };
+
+  await waitForElementToBeRemoved(() => queryByText('Loading...'));
+  global.sendRequestToMock(request, () => {});
+
+  expect(container).toMatchSnapshot();
+});
 
 it('renders 404 when publication not found', () => {
   const component = (

--- a/src/spec/components/Embedded/__snapshots__/Embedded.test.js.snap
+++ b/src/spec/components/Embedded/__snapshots__/Embedded.test.js.snap
@@ -93,3 +93,162 @@ exports[`renders an embedded publication 2`] = `
   </div>
 </div>
 `;
+
+exports[`the API performs a no-op for refreshView 1`] = `
+<div>
+  <div>
+    <div
+      class="treebankContainer"
+    >
+      <div
+        class="text"
+      >
+        <div
+          data-highlight=""
+          data-id="1"
+          data-treebank="1912971948"
+        >
+          Text
+        </div>
+      </div>
+      <div
+        class="graph"
+      >
+        <div
+          data-highlight=""
+          data-id="1"
+          data-treebank="1912971948"
+        >
+          Graph
+        </div>
+      </div>
+      <div
+        data-highlight=""
+        data-id="1"
+        data-treebank="1912971948"
+      >
+        PartOfSpeech
+      </div>
+      <div
+        class="links"
+      >
+        <p>
+          <a
+            href="https://www.example.com/on-the-murder-of-eratosthenes-1-50/1"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Credits and more information
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`the API supports gotoSentence 1`] = `
+<div>
+  <div>
+    <div
+      class="treebankContainer"
+    >
+      <div
+        class="text"
+      >
+        <div
+          data-highlight=""
+          data-id="5"
+          data-treebank="1912971948"
+        >
+          Text
+        </div>
+      </div>
+      <div
+        class="graph"
+      >
+        <div
+          data-highlight=""
+          data-id="5"
+          data-treebank="1912971948"
+        >
+          Graph
+        </div>
+      </div>
+      <div
+        data-highlight=""
+        data-id="5"
+        data-treebank="1912971948"
+      >
+        PartOfSpeech
+      </div>
+      <div
+        class="links"
+      >
+        <p>
+          <a
+            href="https://www.example.com/on-the-murder-of-eratosthenes-1-50/5"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Credits and more information
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`the API supports gotoSentence with highlighted words 1`] = `
+<div>
+  <div>
+    <div
+      class="treebankContainer"
+    >
+      <div
+        class="text"
+      >
+        <div
+          data-highlight="12"
+          data-id="5"
+          data-treebank="1912971948"
+        >
+          Text
+        </div>
+      </div>
+      <div
+        class="graph"
+      >
+        <div
+          data-highlight="12"
+          data-id="5"
+          data-treebank="1912971948"
+        >
+          Graph
+        </div>
+      </div>
+      <div
+        data-highlight="12"
+        data-id="5"
+        data-treebank="1912971948"
+      >
+        PartOfSpeech
+      </div>
+      <div
+        class="links"
+      >
+        <p>
+          <a
+            href="https://www.example.com/on-the-murder-of-eratosthenes-1-50/5"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Credits and more information
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
This PR is part of a series of changes to address https://github.com/perseids-publications/treebank-template/issues/72. The changes are all on branch `v5` (the same branch this PR is set to be merged into).

The goal is to replace the `arethusa-widget` library with `treebank-react`. This has already been done for the user-facing  interface. But it has not yet been done for the embedded interface used by Alpheios (for example on [this page](https://vgorman1.github.io/151-student-practice/Unit_1_Xen_Hell_1_2_1-19_excerpts.html)).

It's more complicated to do for the embedded interface because the embedded interface provides an API for Alpheios to interact with the treebank. This PR does the following:

* Sets up testing for the API
* Implements `gotoSentence`
* Implements `refreshView`

The two other API calls (`getMorph`, `findWord`) will be done in a future PR.
